### PR TITLE
Disable some settings based on selected mode #453

### DIFF
--- a/app/src/main/java/dev/fabik/bluetoothhid/Settings.kt
+++ b/app/src/main/java/dev/fabik/bluetoothhid/Settings.kt
@@ -79,7 +79,9 @@ import dev.fabik.bluetoothhid.ui.SliderPreference
 import dev.fabik.bluetoothhid.ui.SwitchPreference
 import dev.fabik.bluetoothhid.ui.TextBoxPreference
 import dev.fabik.bluetoothhid.ui.rememberDialogState
+import dev.fabik.bluetoothhid.utils.ConnectionMode
 import dev.fabik.bluetoothhid.utils.PreferenceStore
+import dev.fabik.bluetoothhid.utils.rememberEnumPreference
 import dev.fabik.bluetoothhid.utils.rememberPreferenceNull
 import dev.fabik.bluetoothhid.utils.setPreference
 import kotlinx.coroutines.launch
@@ -147,6 +149,8 @@ fun SectionTitle(text: String) {
 
 @Composable
 internal fun ConnectionSettings(strings: SettingsStrings) {
+    val connectionMode by rememberEnumPreference(PreferenceStore.CONNECTION_MODE)
+    val isRfcomm = connectionMode == ConnectionMode.RFCOMM
 
     ComboBoxEnumPreference(
         title = strings[R.string.connection_mode],
@@ -176,6 +180,7 @@ internal fun ConnectionSettings(strings: SettingsStrings) {
         valueFormat = strings[R.string.send_delay_template],
         range = 0f..100f,
         icon = Icons.Default.Timer,
+        enabled = !isRfcomm,
         preference = PreferenceStore.SEND_DELAY
     )
 
@@ -184,6 +189,7 @@ internal fun ConnectionSettings(strings: SettingsStrings) {
         desc = strings[R.string.keyboard_layout_desc],
         icon = Icons.Default.Keyboard,
         values = strings.array(R.array.keyboard_layout_values),
+        enabled = !isRfcomm,
         preference = PreferenceStore.KEYBOARD_LAYOUT
     )
 
@@ -193,6 +199,7 @@ internal fun ConnectionSettings(strings: SettingsStrings) {
         title = strings[R.string.custom_keys],
         desc = strings[R.string.define_custom_keys],
         icon = Icons.Default.KeyboardCommandKey,
+        enabled = !isRfcomm,
         onClick = customKeysDialog::open
     )
 

--- a/app/src/main/java/dev/fabik/bluetoothhid/ui/Preference.kt
+++ b/app/src/main/java/dev/fabik/bluetoothhid/ui/Preference.kt
@@ -9,6 +9,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.graphics.vector.ImageVector
 import dev.fabik.bluetoothhid.utils.PreferenceStore
 import dev.fabik.bluetoothhid.utils.rememberEnumPreference
@@ -21,11 +22,14 @@ fun ButtonPreference(
     desc: String,
     icon: ImageVector? = null,
     extra: (@Composable () -> Unit)? = null,
+    enabled: Boolean = true,
     onClick: () -> Unit = {}
 ) {
     ListItem(
         headlineContent = { Text(title) },
-        modifier = Modifier.clickable(onClick = onClick),
+        modifier = Modifier
+            .alpha(if (enabled) 1f else 0.38f)
+            .clickable(enabled = enabled, onClick = onClick),
         supportingContent = { Text(desc) },
         leadingContent = icon?.let {
             { Icon(icon, null) }
@@ -79,6 +83,7 @@ fun <E : Enum<E>> ComboBoxEnumPreference(
     values: Array<String>,
     icon: ImageVector? = null,
     preference: PreferenceStore.EnumPref<E>,
+    enabled: Boolean = true,
     onReset: () -> Unit = {},
 ) {
     var selectedEnum by rememberEnumPreference(preference)
@@ -89,6 +94,7 @@ fun <E : Enum<E>> ComboBoxEnumPreference(
         selectedEnum.ordinal,
         values,
         icon,
+        enabled,
         onReset = { selectedEnum = preference.getDefaultEnum(); onReset() }
     ) {
         selectedEnum = preference.fromOrdinal(it)
@@ -102,6 +108,7 @@ fun ComboBoxPreference(
     selectedItem: Int?,
     values: Array<String>,
     icon: ImageVector? = null,
+    enabled: Boolean = true,
     onReset: () -> Unit,
     onSelect: (Int) -> Unit
 ) {
@@ -113,7 +120,7 @@ fun ComboBoxPreference(
         }
     }
 
-    ButtonPreference(title, values[selectedItem ?: 0], icon) {
+    ButtonPreference(title, values[selectedItem ?: 0], icon, enabled = enabled) {
         dialogState.open()
     }
 }
@@ -126,6 +133,7 @@ fun SliderPreference(
     range: ClosedFloatingPointRange<Float>,
     steps: Int = 0,
     icon: ImageVector? = null,
+    enabled: Boolean = true,
     preference: PreferenceStore.Preference<Float>
 ) {
     var value by rememberPreferenceNull(preference)
@@ -138,6 +146,7 @@ fun SliderPreference(
         steps,
         range,
         icon,
+        enabled,
         onReset = { value = preference.defaultValue }
     ) {
         value = it
@@ -153,6 +162,7 @@ fun SliderPreference(
     steps: Int = 0,
     range: ClosedFloatingPointRange<Float>,
     icon: ImageVector? = null,
+    enabled: Boolean = true,
     onReset: () -> Unit,
     onSelect: (Float) -> Unit
 ) {
@@ -173,7 +183,7 @@ fun SliderPreference(
         }
     }
 
-    ButtonPreference(title, valueFormat.format(value), icon) {
+    ButtonPreference(title, valueFormat.format(value), icon, enabled = enabled) {
         dialogState.open()
     }
 }
@@ -240,6 +250,7 @@ fun TextBoxPreference(
     descLong: String? = desc,
     validator: (String) -> String? = { null },
     icon: ImageVector? = null,
+    enabled: Boolean = true,
     preference: PreferenceStore.Preference<String>
 ) {
     var value by rememberPreferenceNull(preference)
@@ -251,6 +262,7 @@ fun TextBoxPreference(
         value,
         validator,
         icon,
+        enabled,
         onReset = { value = preference.defaultValue }) {
         value = it
     }
@@ -264,6 +276,7 @@ fun TextBoxPreference(
     value: String?,
     validator: (String) -> String? = { null },
     icon: ImageVector? = null,
+    enabled: Boolean = true,
     onReset: () -> Unit,
     onSelect: (String) -> Unit
 ) {
@@ -282,7 +295,7 @@ fun TextBoxPreference(
         }
     }
 
-    ButtonPreference(title, if (value.isNullOrEmpty()) desc else value, icon) {
+    ButtonPreference(title, if (value.isNullOrEmpty()) desc else value, icon, enabled = enabled) {
         dialogState.open()
     }
 }

--- a/app/src/main/res/values-de-rDE/strings.xml
+++ b/app/src/main/res/values-de-rDE/strings.xml
@@ -323,7 +323,7 @@
     <string name="manual_input">Manuelle Eingabe</string>
     <string name="include_extra_keys">Extra Tasten verwenden</string>
     <string name="connection_mode">Verbindungsmodus</string>
-    <string name="connection_mode_desc">HID emuliert Tastatureingaben, RFCOMM sendet Daten über Bluetooth COM-Port (kann zusätzliche Software erfordern)</string>
+    <string name="connection_mode_desc">HID emuliert Tastatureingaben, RFCOMM sendet Daten über Bluetooth COM-Port (kann zusätzliche Software erfordern). Nicht unterstützte Einstellungen werden im RFCOMM-Modus ausgegraut.</string>
     <string-array name="connection_mode_values">
         <item>HID-Tastatur</item>
         <item>RFCOMM (SPP)</item>

--- a/app/src/main/res/values-pl-rPL/strings.xml
+++ b/app/src/main/res/values-pl-rPL/strings.xml
@@ -237,7 +237,7 @@
     <string name="error_connecting_to_device">Błąd połączenia z urządzeniem! Próba ponownego uruchomienia usługi…</string>
     <string name="developer_mode">Tryb dewelopera</string>
     <string name="connection_mode">Tryb połączenia</string>
-    <string name="connection_mode_desc">HID emuluje klawiaturę, RFCOMM wysyła dane przez port COM Bluetooth (może wymagać dodatkowego oprogramowania)</string>
+    <string name="connection_mode_desc">HID emuluje klawiaturę, RFCOMM wysyła dane przez port COM Bluetooth (może wymagać dodatkowego oprogramowania). Nieobsługiwane ustawienia będą wyszarzone w trybie RFCOMM.</string>
     <string-array name="theme_values">
         <item>System</item>
         <item>Jasny</item>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -288,7 +288,7 @@
     <string name="manual_input">Manual input</string>
     <string name="include_extra_keys">Include extra keys</string>
     <string name="connection_mode">Connection Mode</string>
-    <string name="connection_mode_desc">HID emulates keyboard input, RFCOMM sends data via Bluetooth COM port (may require additional software)</string>
+    <string name="connection_mode_desc">HID emulates keyboard input, RFCOMM sends data via Bluetooth COM port (may require additional software). Unsupported settings will be greyed out in RFCOMM mode.</string>
     <string-array name="theme_values">
         <item>System</item>
         <item>Light</item>


### PR DESCRIPTION
Disables settings that are not supported in RFCOMM mode by greying them out.

Settings disabled in RFCOMM mode:
- Send delay (HID-only keystroke timing)
- Keyboard layout (HID-only keycode conversion)
- Custom keys (HID-only custom keycodes)

Extra keys remains enabled (needed for CUSTOM option which activates custom template).

Updated connection mode description in all languages (EN, DE, PL).

Fixes #453