### PR TITLE
GitHub Actions update #527 + fixes for Regex / JS specified issues

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,9 @@ updates:
     schedule:
       interval: "daily"
     open-pull-requests-limit: 10
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -14,10 +14,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '17'
           distribution: 'temurin'

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -14,10 +14,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: '17'
           distribution: 'temurin'
@@ -49,7 +49,7 @@ jobs:
         run: rm $GITHUB_WORKSPACE/signing-key.jks
 
       - name: Create Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v3
         with:
           generate_release_notes: true
           draft: true

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -12,7 +12,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v8
+      - uses: actions/stale@v10
         with:
           exempt-issue-labels: 'work-in-progress,enhancement,bug'
           exempt-pr-labels: 'work-in-progress,dependencies'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,10 +19,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '17'
           distribution: 'temurin'
@@ -38,7 +38,7 @@ jobs:
         run: ./gradlew assembleDebug
 
       - name: Upload Debug APK
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: APK(s) debug generated
           path: ./app/build/outputs/apk/debug/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,10 +17,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: '17'
           distribution: 'temurin'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,10 +6,12 @@ on:
     paths:
       - 'app/**'
       - 'build.gradle'
+      - '.github/workflows/**'
   pull_request:
     paths:
       - 'app/**'
       - 'build.gradle'
+      - '.github/workflows/**'
 
 jobs:
   build:

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -86,10 +86,6 @@ android {
         buildConfig = true
     }
 
-    composeOptions {
-        kotlinCompilerExtensionVersion = '1.4.2'
-    }
-
     packagingOptions {
         resources {
             excludes += '/META-INF/{AL2.0,LGPL2.1}'

--- a/app/src/main/java/dev/fabik/bluetoothhid/Scanner.kt
+++ b/app/src/main/java/dev/fabik/bluetoothhid/Scanner.kt
@@ -114,6 +114,7 @@ import dev.fabik.bluetoothhid.ui.InfoDialog
 import dev.fabik.bluetoothhid.ui.LocalNavigation
 import dev.fabik.bluetoothhid.ui.RequiresCameraPermission
 import dev.fabik.bluetoothhid.ui.Routes
+import dev.fabik.bluetoothhid.ui.model.BarcodeResult
 import dev.fabik.bluetoothhid.ui.model.CameraViewModel
 import dev.fabik.bluetoothhid.ui.rememberDialogState
 import dev.fabik.bluetoothhid.ui.tooltip
@@ -180,21 +181,19 @@ fun BoxScope.ElevatedWarningCard(
  * Scanner screen with camera preview.
  *
  * @param currentDevice the device that is currently connected, can be null if no device is connected
- * @param sendText callback to send text and format to the current device
+ * @param sendText callback to send the scanned barcode result to the current device
  */
 @Composable
 fun Scanner(
     currentDevice: BluetoothDevice?,
-    sendText: (String, Int?, String?) -> Unit
+    sendText: (BarcodeResult) -> Unit
 ) {
     val context = LocalContext.current
 
-    var currentBarcode by rememberSaveable { mutableStateOf<String?>(null) }
-    var currentBarcodeFormat by rememberSaveable { mutableStateOf<Int?>(null) }
-    var currentImageName by rememberSaveable { mutableStateOf<String?>(null) }
+    var currentResult by remember { mutableStateOf<BarcodeResult?>(null) }
 
-    val currentSendText = remember(currentBarcode, currentBarcodeFormat, currentImageName) {
-        { -> currentBarcode?.let { sendText(it, currentBarcodeFormat, currentImageName) } }
+    val currentSendText = remember(currentResult) {
+        { -> currentResult?.let { sendText(it) } }
     }
 
     var cameraControl by remember { mutableStateOf<CameraControl?>(null) }
@@ -227,14 +226,12 @@ fun Scanner(
             currentDevice?.let {
                 val clearAfterSend by context.getPreferenceState(PreferenceStore.CLEAR_AFTER_SEND)
 
-                currentBarcode?.let {
+                currentResult?.let {
                     SendToDeviceFAB {
                         currentSendText()
 
                         if (clearAfterSend == true) {
-                            currentBarcode = null
-                            currentBarcodeFormat = null
-                            currentImageName = null
+                            currentResult = null
                             cameraVM.lastBarcode = null
                         }
                     }
@@ -251,11 +248,9 @@ fun Scanner(
             RequiresCameraPermission {
                 CameraPreviewArea(onCameraReady = { control, info, capt ->
                     cameraControl = control; cameraInfo = info
-                }) { value, format, imageName, send ->
-                    currentBarcode = value
-                    currentBarcodeFormat = format
-                    currentImageName = imageName
-                    if (send && value?.isNotEmpty() == true) {
+                }) { result, send ->
+                    currentResult = result
+                    if (send && result?.text?.isNotEmpty() == true) {
                         currentSendText()
                     }
                 }
@@ -287,9 +282,7 @@ fun Scanner(
                     VolumeKeyAction.TOGGLE_FLASH -> cameraControl?.enableTorch(cameraInfo?.torchState?.value == TorchState.OFF)
                     VolumeKeyAction.TRIGGER_FOCUS -> cameraVM.focusAtCenter()
                     VolumeKeyAction.CLEAR_VALUE -> {
-                        currentBarcode = null
-                        currentBarcodeFormat = null
-                        currentImageName = null
+                        currentResult = null
                         cameraVM.lastBarcode = null
                     }
 
@@ -343,7 +336,7 @@ fun Scanner(
             contentAlignment = Alignment.Center
         ) {
 
-            BarcodeValue(currentBarcode)
+            BarcodeValue(currentResult?.text)
             CapsLockWarning()
             DeviceStatusIndicator()
 
@@ -389,12 +382,13 @@ fun AdaptSystemBarsColor(fullScreen: Boolean) {
  * Area for the camera preview.
  *
  * @param onCameraReady callback to be called when the camera is ready
- * @param onBarcodeDetected callback to be called when a barcode is detected (value, format, scanImageName, autoSend)
+ * @param onBarcodeDetected callback invoked when a barcode is detected (result, autoSend).
+ *   A null result means the barcode left the frame.
  */
 @Composable
 private fun CameraPreviewArea(
     onCameraReady: (CameraControl?, CameraInfo?, ImageCapture?) -> Unit,
-    onBarcodeDetected: (String?, Int?, String?, Boolean) -> Unit,
+    onBarcodeDetected: (BarcodeResult?, Boolean) -> Unit,
 ) {
     val context = LocalContext.current
 
@@ -439,10 +433,10 @@ private fun CameraPreviewArea(
         "Scanner initialized - vibrate: $vibrate, hasVibrator: ${vibrator.hasVibrator()}, SDK: ${Build.VERSION.SDK_INT}"
     )
 
-    CameraPreviewContent(onCameraReady = onCameraReady) { value, format, imageName ->
-        Log.d("Scanner", "Barcode detected: $value")
-        onBarcodeDetected(value, format, imageName, autoSend)
-        if (value == null) return@CameraPreviewContent
+    CameraPreviewContent(onCameraReady = onCameraReady) { result ->
+        Log.d("Scanner", "Barcode detected: ${result?.text}")
+        onBarcodeDetected(result, result != null && autoSend)
+        if (result == null) return@CameraPreviewContent
 
         if (playSound) {
             runCatching {
@@ -475,7 +469,7 @@ private fun CameraPreviewArea(
         }
 
         if (copyToClipboard) {
-            clipboardScope.launch { clipboard.setClipEntry(ClipEntry(ClipData.newPlainText("", value))) }
+            clipboardScope.launch { clipboard.setClipEntry(ClipEntry(ClipData.newPlainText("", result.text))) }
         }
     }
 }

--- a/app/src/main/java/dev/fabik/bluetoothhid/Scanner.kt
+++ b/app/src/main/java/dev/fabik/bluetoothhid/Scanner.kt
@@ -208,6 +208,16 @@ fun Scanner(
     val keyboardDialog = rememberDialogState()
     val cameraVM = viewModel<CameraViewModel>()
 
+    // Show a Snackbar when JavaScript evaluation fails
+    LaunchedEffect(cameraVM) {
+        cameraVM.jsErrors.collect { error ->
+            snackbarHostState.showSnackbar(
+                message = context.getString(R.string.js_error, error),
+                withDismissAction = true
+            )
+        }
+    }
+
     Scaffold(
         topBar = {
             ScannerAppBar(cameraControl, cameraInfo, currentDevice, fullScreen, keyboardDialog)

--- a/app/src/main/java/dev/fabik/bluetoothhid/bt/BluetoothController.kt
+++ b/app/src/main/java/dev/fabik/bluetoothhid/bt/BluetoothController.kt
@@ -478,7 +478,8 @@ class BluetoothController(var context: Context) {
         from: String = "SCAN",
         scanTimestamp: Long? = null,
         barcodeType: String? = null,
-        imageName: String? = null
+        imageName: String? = null,
+        regexGroups: List<String> = emptyList()
     ) = with(context) {
         if (!_isSending.compareAndSet(expect = false, update = true)) {
             return@with
@@ -515,7 +516,8 @@ class BluetoothController(var context: Context) {
                 scannerID,
                 barcodeType,
                 preserveUnsupported,  // Pass preference
-                imageName
+                imageName,
+                regexGroups
             )
             rfcommController.sendProcessedData(processedString)
         } else {
@@ -529,7 +531,8 @@ class BluetoothController(var context: Context) {
                 scannerID,
                 barcodeType,
                 false,  // HID always false - placeholders needed for KeyTranslator
-                imageName
+                imageName,
+                regexGroups
             )
             keyboardSender?.sendProcessedString(
                 processedString,

--- a/app/src/main/java/dev/fabik/bluetoothhid/ui/CameraPreview.kt
+++ b/app/src/main/java/dev/fabik/bluetoothhid/ui/CameraPreview.kt
@@ -67,6 +67,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import dev.fabik.bluetoothhid.LocalJsEngineService
 import dev.fabik.bluetoothhid.R
+import dev.fabik.bluetoothhid.ui.model.BarcodeResult
 import dev.fabik.bluetoothhid.ui.model.CameraViewModel
 import dev.fabik.bluetoothhid.utils.ComposableLifecycle
 import dev.fabik.bluetoothhid.utils.PreferenceStore
@@ -80,7 +81,7 @@ import zxingcpp.BarcodeReader
 fun CameraPreviewContent(
     viewModel: CameraViewModel = viewModel<CameraViewModel>(),
     onCameraReady: (CameraControl?, CameraInfo?, ImageCapture?) -> Unit,
-    onBarcodeDetected: (String?, Int, String?) -> Unit,
+    onBarcodeDetected: (BarcodeResult?) -> Unit,
 ) {
     val context = LocalContext.current
     val lifecycleOwner = LocalLifecycleOwner.current
@@ -355,7 +356,7 @@ private fun OcrDetectionFAB(viewModel: CameraViewModel) {
         onConfirm = {
             viewModel.onBarcodeDetected(
                 selectedTexts.map { e -> e.value }.joinToString("\n"),
-                BarcodeReader.Format.NONE, null
+                BarcodeReader.Format.NONE, null, emptyList()
             )
             close()
         }

--- a/app/src/main/java/dev/fabik/bluetoothhid/ui/JsEditor.kt
+++ b/app/src/main/java/dev/fabik/bluetoothhid/ui/JsEditor.kt
@@ -130,9 +130,11 @@ fun JavaScriptEditorDialog(jsDialog: DialogState) {
                 scope.launch {
                     outputText = ""
 
-                    val result = jsEngine?.evaluateTemplate(code, value, type) { message ->
-                        outputText += message + "\n"
-                    }
+                    val result = jsEngine?.evaluateTemplate(
+                        code, value, type,
+                        onOutput = { message -> outputText += message + "\n" },
+                        onException = { throwable -> outputText += "Error: ${throwable.message ?: "Unknown error"}\n" }
+                    )
 
                     outputText += when {
                         result == null -> "JSEngine not initialized or unsupported! Make sure that you have enabled the feature."

--- a/app/src/main/java/dev/fabik/bluetoothhid/ui/JsEditor.kt
+++ b/app/src/main/java/dev/fabik/bluetoothhid/ui/JsEditor.kt
@@ -1,11 +1,15 @@
 package dev.fabik.bluetoothhid.ui
 
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.input.InputTransformation
+import androidx.compose.foundation.text.input.TextFieldBuffer
+import androidx.compose.foundation.text.input.rememberTextFieldState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
@@ -19,6 +23,7 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -26,6 +31,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
@@ -40,6 +46,61 @@ import dev.fabik.bluetoothhid.utils.PreferenceStore
 import dev.fabik.bluetoothhid.utils.rememberJsEngineService
 import dev.fabik.bluetoothhid.utils.rememberPreference
 import kotlinx.coroutines.launch
+
+/**
+ * Input transformation for the JavaScript editor that provides minimal IDE-like assistance:
+ * - Auto-pairs quotes (" and ') and brackets ({}, (), [])
+ * - Inserts a new line with the same indentation after a semicolon
+ * - Preserves the indentation of the previous line when pressing Enter
+ */
+@OptIn(ExperimentalFoundationApi::class)
+private object JsInputTransformation : InputTransformation {
+    override fun TextFieldBuffer.transformInput() {
+        // Only handle single-change events (ignore multi-change e.g. paste)
+        if (changes.changeCount != 1) return
+
+        val originalRange = changes.getOriginalRange(0)
+        val newRange = changes.getRange(0)
+
+        // Only handle single character insertions (no deletions or replacements)
+        if (originalRange.length != 0 || newRange.length != 1) return
+
+        val cursor = newRange.end
+        val insertedChar = asCharSequence()[newRange.start]
+
+        when (insertedChar) {
+            // Auto-pair quotes: insert closing quote and keep cursor between them
+            '"', '\'' -> {
+                // Skip if the next char is already the same quote (avoid double-pairing)
+                if (asCharSequence().getOrNull(cursor) == insertedChar) return
+                replace(cursor, cursor, insertedChar.toString())
+                placeCursorBeforeCharAt(cursor)
+            }
+            // Auto-pair brackets: insert closing bracket and keep cursor between them
+            '(' -> { replace(cursor, cursor, ")"); placeCursorBeforeCharAt(cursor) }
+            '[' -> { replace(cursor, cursor, "]"); placeCursorBeforeCharAt(cursor) }
+            '{' -> { replace(cursor, cursor, "}"); placeCursorBeforeCharAt(cursor) }
+            // Semicolon: insert a new line with the same indentation as the current line
+            ';' -> {
+                val text = asCharSequence().toString()
+                val lineStart = (text.lastIndexOf('\n', cursor - 2) + 1).coerceAtLeast(0)
+                val indentation = text.substring(lineStart, cursor - 1).takeWhile { it == ' ' || it == '\t' }
+                replace(cursor, cursor, "\n$indentation")
+                placeCursorAfterCharAt(cursor + indentation.length)
+            }
+            // Enter: preserve the indentation of the previous line
+            '\n' -> {
+                val text = asCharSequence().toString()
+                val lineStart = (text.lastIndexOf('\n', cursor - 2) + 1).coerceAtLeast(0)
+                val indentation = text.substring(lineStart, cursor - 1).takeWhile { it == ' ' || it == '\t' }
+                if (indentation.isNotEmpty()) {
+                    replace(cursor, cursor, indentation)
+                    placeCursorAfterCharAt(cursor + indentation.length - 1)
+                }
+            }
+        }
+    }
+}
 
 @Composable
 fun JavaScriptEditorDialog(jsDialog: DialogState) {
@@ -94,12 +155,17 @@ fun JavaScriptEditor(
     onEdit: (String) -> Unit,
     outputText: String
 ) {
-    var codeText by remember { mutableStateOf(TextFieldValue(initialCode)) }
+    val codeState = rememberTextFieldState(initialCode)
     var valueText by remember { mutableStateOf(TextFieldValue("")) }
     var typeText by remember { mutableStateOf("") }
 
     val currentOnRunClicked by rememberUpdatedState(onRunClicked)
     val currentOnEdit by rememberUpdatedState(onEdit)
+
+    // Notify parent of text changes
+    LaunchedEffect(Unit) {
+        snapshotFlow { codeState.text.toString() }.collect { currentOnEdit(it) }
+    }
 
     Column(Modifier.verticalScroll(rememberScrollState())) {
         Text(stringResource(R.string.editor_desc))
@@ -110,10 +176,10 @@ fun JavaScriptEditor(
             modifier = Modifier.padding(top = 8.dp)
         )
 
-        // JavaScript code editor
+        // JavaScript code editor with auto-complete assistance
         TextField(
-            value = codeText,
-            onValueChange = { codeText = it; currentOnEdit(it.text) },
+            state = codeState,
+            inputTransformation = JsInputTransformation,
             textStyle = TextStyle(),
             modifier = Modifier
                 .fillMaxWidth()
@@ -188,7 +254,7 @@ fun JavaScriptEditor(
 
         // Run button
         Button(
-            onClick = { currentOnRunClicked(codeText.text, valueText.text, typeText) },
+            onClick = { currentOnRunClicked(codeState.text.toString(), valueText.text, typeText) },
             modifier = Modifier
                 .align(Alignment.End)
                 .padding(top = 8.dp)

--- a/app/src/main/java/dev/fabik/bluetoothhid/ui/Navigation.kt
+++ b/app/src/main/java/dev/fabik/bluetoothhid/ui/Navigation.kt
@@ -19,13 +19,12 @@ import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
-import androidx.lifecycle.viewmodel.compose.viewModel
 import dev.fabik.bluetoothhid.Devices
 import dev.fabik.bluetoothhid.History
 import dev.fabik.bluetoothhid.LocalController
 import dev.fabik.bluetoothhid.R
 import dev.fabik.bluetoothhid.Scanner
-import dev.fabik.bluetoothhid.ui.model.CameraViewModel
+import dev.fabik.bluetoothhid.ui.model.BarcodeResult
 import dev.fabik.bluetoothhid.utils.ZXingAnalyzer
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -96,18 +95,17 @@ fun NavGraph() {
             }
 
             composable(Routes.Main) {
-                val cameraVM = viewModel<CameraViewModel>()
-                Scanner(currentDevice) { text, format, imageName ->
+                Scanner(currentDevice) { result: BarcodeResult ->
                     scope.launch {
-                        val barcodeType = format?.let { ZXingAnalyzer.index2String(it) }
+                        val barcodeType = ZXingAnalyzer.index2String(result.format)
                         controller?.sendString(
-                            text,
+                            result.text,
                             true,
                             "SCAN",
                             null,
                             barcodeType,
-                            imageName = imageName,
-                            regexGroups = cameraVM.lastRegexGroups
+                            imageName = result.imageName,
+                            regexGroups = result.regexGroups
                         )
                     }
                 }

--- a/app/src/main/java/dev/fabik/bluetoothhid/ui/Navigation.kt
+++ b/app/src/main/java/dev/fabik/bluetoothhid/ui/Navigation.kt
@@ -19,11 +19,13 @@ import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
+import androidx.lifecycle.viewmodel.compose.viewModel
 import dev.fabik.bluetoothhid.Devices
 import dev.fabik.bluetoothhid.History
 import dev.fabik.bluetoothhid.LocalController
 import dev.fabik.bluetoothhid.R
 import dev.fabik.bluetoothhid.Scanner
+import dev.fabik.bluetoothhid.ui.model.CameraViewModel
 import dev.fabik.bluetoothhid.utils.ZXingAnalyzer
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -94,6 +96,7 @@ fun NavGraph() {
             }
 
             composable(Routes.Main) {
+                val cameraVM = viewModel<CameraViewModel>()
                 Scanner(currentDevice) { text, format, imageName ->
                     scope.launch {
                         val barcodeType = format?.let { ZXingAnalyzer.index2String(it) }
@@ -103,7 +106,8 @@ fun NavGraph() {
                             "SCAN",
                             null,
                             barcodeType,
-                            imageName = imageName
+                            imageName = imageName,
+                            regexGroups = cameraVM.lastRegexGroups
                         )
                     }
                 }

--- a/app/src/main/java/dev/fabik/bluetoothhid/ui/model/BarcodeResult.kt
+++ b/app/src/main/java/dev/fabik/bluetoothhid/ui/model/BarcodeResult.kt
@@ -1,0 +1,17 @@
+package dev.fabik.bluetoothhid.ui.model
+
+/**
+ * Represents a fully processed barcode scan result, including all data needed for template
+ * processing and transmission.
+ *
+ * @param text     The processed barcode value (after regex/JS transforms).
+ * @param format   The barcode format index (see [dev.fabik.bluetoothhid.utils.ZXingAnalyzer]).
+ * @param imageName The name of the saved scan image, or null if not saved.
+ * @param regexGroups Capture groups from the filter regex (1..N). Empty if no regex or no groups.
+ */
+data class BarcodeResult(
+    val text: String,
+    val format: Int,
+    val imageName: String?,
+    val regexGroups: List<String> = emptyList()
+)

--- a/app/src/main/java/dev/fabik/bluetoothhid/ui/model/CameraViewModel.kt
+++ b/app/src/main/java/dev/fabik/bluetoothhid/ui/model/CameraViewModel.kt
@@ -61,8 +61,11 @@ import dev.fabik.bluetoothhid.utils.TextMode
 import dev.fabik.bluetoothhid.utils.ZXingAnalyzer
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
@@ -90,6 +93,10 @@ class CameraViewModel : ViewModel() {
     private val _surfaceRequest = MutableStateFlow<SurfaceRequest?>(null)
     val surfaceRequest: StateFlow<SurfaceRequest?> = _surfaceRequest.asStateFlow()
 
+    // Emits error messages when JavaScript evaluation fails
+    private val _jsErrors = MutableSharedFlow<String>(extraBufferCapacity = 1)
+    val jsErrors: SharedFlow<String> = _jsErrors.asSharedFlow()
+
     private var surfaceMeteringPointFactory: SurfaceOrientedMeteringPointFactory? = null
     private var cameraControl: CameraControl? = null
     private var cameraInfo: CameraInfo? = null
@@ -97,6 +104,9 @@ class CameraViewModel : ViewModel() {
     private var barcodeAnalyzer: ZXingAnalyzer? = null
 
     var onBarcodeDetected: (String?, BarcodeReader.Format, ImageProxy?) -> Unit = { _, _, _ -> }
+
+    // Regex capture groups from the last scanned barcode (groups 1..N, group 0 is the full match)
+    var lastRegexGroups: List<String> = emptyList()
 
     var scanRect = Rect.Zero
     var overlayPosition by mutableStateOf<Offset?>(null)
@@ -479,12 +489,19 @@ class CameraViewModel : ViewModel() {
             var value = v
 
             _scanRegex?.let { re ->
-                // extract first capture group if it exists
+                // extract regex capture groups if they exist
                 re.find(value)?.let { match ->
+                    // Store all capture groups (1..N) for {CODE%N} template support
+                    lastRegexGroups = match.groupValues.drop(1)
+                    // Use first capture group as the main value (backward compat)
                     match.groupValues.getOrNull(1)?.let { group ->
                         value = group
                     }
+                } ?: run {
+                    lastRegexGroups = emptyList()
                 }
+            } ?: run {
+                lastRegexGroups = emptyList()
             }
 
             _jsEngineService?.let { s ->
@@ -691,11 +708,25 @@ class CameraViewModel : ViewModel() {
         value: String,
         format: String
     ): String {
-        return service.evaluateTemplate(
+        var lastError: String? = null
+
+        val result = service.evaluateTemplate(
             _jsCode ?: return value,
             value,
             format,
-        ) ?: value
+        ) { message ->
+            // Capture error messages (ignore execution start/end markers)
+            if (!message.startsWith("---")) {
+                lastError = message
+            }
+        }
+
+        if (result == null) {
+            // Emit the captured error message (or a generic fallback) for UI display
+            _jsErrors.tryEmit(lastError ?: "JS evaluation failed")
+        }
+
+        return result ?: value
     }
 
     suspend fun tapToFocus(tapCoords: Offset) {

--- a/app/src/main/java/dev/fabik/bluetoothhid/ui/model/CameraViewModel.kt
+++ b/app/src/main/java/dev/fabik/bluetoothhid/ui/model/CameraViewModel.kt
@@ -59,6 +59,7 @@ import dev.fabik.bluetoothhid.utils.ScanImageFormat
 import dev.fabik.bluetoothhid.utils.ScanResolution
 import dev.fabik.bluetoothhid.utils.TextMode
 import dev.fabik.bluetoothhid.utils.ZXingAnalyzer
+import dev.fabik.bluetoothhid.ui.model.BarcodeResult
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -103,10 +104,10 @@ class CameraViewModel : ViewModel() {
     var imageCapture: ImageCapture? = null
     private var barcodeAnalyzer: ZXingAnalyzer? = null
 
-    var onBarcodeDetected: (String?, BarcodeReader.Format, ImageProxy?) -> Unit = { _, _, _ -> }
-
-    // Regex capture groups from the last scanned barcode (groups 1..N, group 0 is the full match)
-    var lastRegexGroups: List<String> = emptyList()
+    // Internal callback: carries the processed value, format, image and regex capture groups.
+    // regexGroups contains groups 1..N from the filter regex (empty if no regex or no groups).
+    var onBarcodeDetected: (String?, BarcodeReader.Format, ImageProxy?, List<String>) -> Unit =
+        { _, _, _, _ -> }
 
     var scanRect = Rect.Zero
     var overlayPosition by mutableStateOf<Offset?>(null)
@@ -144,18 +145,18 @@ class CameraViewModel : ViewModel() {
         stabilization: Boolean,
         initialZoom: Float,
         onCameraReady: (CameraControl?, CameraInfo?, ImageCapture?) -> Unit,
-        onBarcode: (String?, Int, String?) -> Unit,
+        onBarcode: (BarcodeResult?) -> Unit,
     ) {
         Log.d(TAG, "Binding camera...")
         val processCameraProvider = ProcessCameraProvider.awaitInstance(appContext)
 
-        onBarcodeDetected = { value, format, image ->
+        onBarcodeDetected = { value, format, image, regexGroups ->
             lastDetectionTime = System.currentTimeMillis()
             if (value == null) {
                 if (lastBarcode != null) {
                     Log.d(TAG, "Clearing barcode value")
                     viewModelScope.launch {
-                        onBarcode(null, 0, null)
+                        onBarcode(null)
                     }
                     lastBarcode = null
                 }
@@ -183,7 +184,7 @@ class CameraViewModel : ViewModel() {
                 }
 
                 viewModelScope.launch {
-                    onBarcode(value, formatIdx, scanImageName)
+                    onBarcode(BarcodeResult(value, formatIdx, scanImageName, regexGroups))
                 }
                 lastBarcode = value
             }
@@ -308,7 +309,7 @@ class CameraViewModel : ViewModel() {
             val now = System.currentTimeMillis()
             if (now - (lastDetectionTime ?: now) >= it) {
                 _currentBarcode.update { null }
-                onBarcodeDetected(null, BarcodeReader.Format.NONE, null)
+                onBarcodeDetected(null, BarcodeReader.Format.NONE, null, emptyList())
                 lastDetectionTime = null
             }
         }
@@ -488,31 +489,28 @@ class CameraViewModel : ViewModel() {
         barcode?.value?.let { v ->
             var value = v
 
-            _scanRegex?.let { re ->
-                // extract regex capture groups if they exist
+            // Compute regex capture groups locally — passed directly through the callback chain
+            // instead of being stored as ViewModel state, to avoid threading issues.
+            val regexGroups: List<String> = _scanRegex?.let { re ->
                 re.find(value)?.let { match ->
-                    // Store all capture groups (1..N) for {CODE%N} template support
-                    lastRegexGroups = match.groupValues.drop(1)
                     // Use first capture group as the main value (backward compat)
                     match.groupValues.getOrNull(1)?.let { group ->
                         value = group
                     }
-                } ?: run {
-                    lastRegexGroups = emptyList()
-                }
-            } ?: run {
-                lastRegexGroups = emptyList()
-            }
+                    // Return all capture groups (1..N) for {CODE%N} template support
+                    match.groupValues.drop(1)
+                } ?: emptyList()
+            } ?: emptyList()
 
             _jsEngineService?.let { s ->
                 // Only blocks the analyzer thread
                 runBlocking {
                     value =
                         mapJS(s, value, ZXingAnalyzer.format2String(barcode.format))
-                    onBarcodeDetected(value, barcode.format, sourceImage)
+                    onBarcodeDetected(value, barcode.format, sourceImage, regexGroups)
                 }
             } ?: run {
-                onBarcodeDetected(value, barcode.format, sourceImage)
+                onBarcodeDetected(value, barcode.format, sourceImage, regexGroups)
             }
         }
     }
@@ -556,7 +554,7 @@ class CameraViewModel : ViewModel() {
             _ocrResults.update { _ -> results }
             return true
         } else if (results.isNotEmpty()) {
-            onBarcodeDetected(results.first().text, BarcodeReader.Format.NONE, null)
+            onBarcodeDetected(results.first().text, BarcodeReader.Format.NONE, null, emptyList())
         }
 
         return false
@@ -708,23 +706,16 @@ class CameraViewModel : ViewModel() {
         value: String,
         format: String
     ): String {
-        var lastError: String? = null
-
         val result = service.evaluateTemplate(
             _jsCode ?: return value,
             value,
             format,
-        ) { message ->
-            // Capture error messages (ignore execution start/end markers)
-            if (!message.startsWith("---")) {
-                lastError = message
+            onException = { throwable ->
+                // Emit the actual exception message for UI display (Snackbar in Scanner).
+                // console.log output goes through onOutput (null here) and is not shown as errors.
+                _jsErrors.tryEmit(throwable.message ?: "JS evaluation failed")
             }
-        }
-
-        if (result == null) {
-            // Emit the captured error message (or a generic fallback) for UI display
-            _jsErrors.tryEmit(lastError ?: "JS evaluation failed")
-        }
+        )
 
         return result ?: value
     }

--- a/app/src/main/java/dev/fabik/bluetoothhid/utils/JsEngineService.kt
+++ b/app/src/main/java/dev/fabik/bluetoothhid/utils/JsEngineService.kt
@@ -81,7 +81,11 @@ class JsEngineService : Service() {
     override fun onBind(intent: Intent?): IBinder = binder
 
     @SuppressLint("RequiresFeature")
-    suspend fun evaluate(code: String, onOutput: ((String) -> Unit)? = null): String? {
+    suspend fun evaluate(
+        code: String,
+        onOutput: ((String) -> Unit)? = null,
+        onException: ((Throwable) -> Unit)? = null
+    ): String? {
         var result: String? = "Error: Unable to create isolate!"
 
         jsSandbox?.createIsolate()?.let {
@@ -109,7 +113,9 @@ class JsEngineService : Service() {
                         it.resume(future.get(1, TimeUnit.SECONDS))
                     }.onFailure { err ->
                         Log.e(TAG, "Failed to evaluate code", err)
-                        onOutput?.invoke(err.cause?.message ?: err.message ?: err.toString())
+                        // Route the actual exception to onException, not onOutput,
+                        // so callers can distinguish console.log output from errors.
+                        onException?.invoke(err.cause ?: err)
                         it.resume(null)
                     }
                 }
@@ -125,14 +131,18 @@ class JsEngineService : Service() {
     }
 
     inner class LocalBinder : Binder() {
-        private suspend fun evaluate(code: String, onOutput: ((String) -> Unit)? = null) =
-            this@JsEngineService.evaluate(code, onOutput)
+        private suspend fun evaluate(
+            code: String,
+            onOutput: ((String) -> Unit)? = null,
+            onException: ((Throwable) -> Unit)? = null
+        ) = this@JsEngineService.evaluate(code, onOutput, onException)
 
         suspend fun evaluateTemplate(
             code: String,
             value: String,
             type: String,
-            onOutput: ((String) -> Unit)? = null
+            onOutput: ((String) -> Unit)? = null,
+            onException: ((Throwable) -> Unit)? = null
         ): String? {
             val escapedVal = value.replace("\\", "\\\\").replace("\"", "\\\"")
 
@@ -141,7 +151,7 @@ class JsEngineService : Service() {
             const code = "$escapedVal";
             $code""".trimIndent()
 
-            return evaluate(template, onOutput)
+            return evaluate(template, onOutput, onException)
         }
     }
 

--- a/app/src/main/java/dev/fabik/bluetoothhid/utils/TemplateProcessor.kt
+++ b/app/src/main/java/dev/fabik/bluetoothhid/utils/TemplateProcessor.kt
@@ -213,10 +213,11 @@ object TemplateProcessor {
         scannerId: String? = null,
         barcodeType: String? = null,
         preserveUnsupportedPlaceholders: Boolean = false,
-        scanImageFileName: String? = null
+        scanImageFileName: String? = null,
+        regexGroups: List<String> = emptyList()
     ): String {
-        // Validation - ensure template contains at least one CODE placeholder
-        val codeRegex = Regex("\\{[^{}]*CODE[^{}]*\\}")
+        // Validation - ensure template contains at least one CODE placeholder (including {CODE%N} syntax)
+        val codeRegex = Regex("\\{[^{}]*CODE[^{}]*\\}|\\{CODE%\\d+\\}")
         if (!codeRegex.containsMatchIn(template)) {
             Log.e(TAG, "Template must contain at least one {CODE...} placeholder")
             return data // Fallback to raw data
@@ -250,6 +251,14 @@ object TemplateProcessor {
 
         // Begin template processing
         var processedTemplate = template
+
+        // Phase 0: Process {CODE%N} capture group placeholders
+        // {CODE%1} = first capture group, {CODE%2} = second, etc.
+        // Falls back to data (first group / full match) if the group doesn't exist
+        processedTemplate = processedTemplate.replace(Regex("\\{CODE%(\\d+)\\}")) { match ->
+            val groupIndex = match.groupValues[1].toIntOrNull() ?: 0
+            regexGroups.getOrElse(groupIndex - 1) { data }
+        }
 
         // Phase 1: Extract and remove global encoding placeholders
         val globalEncodings = extractGlobalEncodings(processedTemplate)

--- a/app/src/main/res/values-de-rDE/strings.xml
+++ b/app/src/main/res/values-de-rDE/strings.xml
@@ -184,9 +184,10 @@
     <string name="filter_desc_long">Unterstützt normale Regex Syntax. Benutze eine leere Zeichenkette oder .* um alles zu erfassen. Falls der Regex eine Capture-Gruppe "(…)" enthält, wird der Wert der ersten Gruppe verwendet.</string>
     <string name="custom_template">Eigenes Template</string>
     <string name="custom_templ_desc">Erlaubt ein eigenes Template festzulegen</string>
-    <string name="custom_templ_desc_long">Stellen Sie sicher, dass \'Extra Tasten\' auf \'Benutzerdefiniert\' eingestellt ist.\n\n
+    <string name="custom_templ_desc_long" formatted="false">Stellen Sie sicher, dass \'Extra Tasten\' auf \'Benutzerdefiniert\' eingestellt ist.\n\n
         CODE Platzhalter:\n
-        • {CODE} - einfacher Barcode\n
+        • {CODE} - einfacher Barcode-Wert\n
+        • {CODE%N} - N-te Regex-Erfassungsgruppe (z.B. {CODE%1}, {CODE%2}); fällt auf {CODE} zurück, wenn die Gruppe nicht existiert oder kein Regex gesetzt ist\n
         • Kodierung: _HEX, _B64 können in beliebiger Reihenfolge kombiniert werden\n
         • Beispiele: {CODE_HEX}, {CODE_B64}, {CODE_HEX_B64}, {HEX_B64_CODE}\n\n
         Datum/Zeit Platzhalter mit optionaler Formatierung:\n
@@ -267,6 +268,7 @@
     <string name="camera_error">Kamera Fehler!</string>
     <string name="camera_error_desc">Fehler beim Initialisieren der Kamera. Bitte starten Sie die App oder das Gerät neu. Wenn dieses Problem weiterhin auftritt, melden Sie dies bitte auf Github.</string>
     <string name="press_run_to_evaluate">Drücke Ausführen zum starten</string>
+    <string name="js_error">JS-Fehler: %s</string>
     <string name="custom_javascript">Benutzerdefiniertes JavaScript</string>
     <string name="custom_js_desc">Bearbeite den gescannten Wert mit JS</string>
     <string name="editor_desc">Ermöglicht die Eingabe von beliebigem JavaScript, um den Wert des Codes zu ändern. Es sind zwei Konstanten definiert (\'format\' und \'code\'). Die letzte Anweisung wird als Ergebnis verwendet (kein return erforderlich).</string>

--- a/app/src/main/res/values-pl-rPL/strings.xml
+++ b/app/src/main/res/values-pl-rPL/strings.xml
@@ -139,9 +139,10 @@
     <string name="filter_desc_long">Obsługuje typową składnię regex. Użyj pustego ciągu lub .*, aby dopasować wszystko. Jeśli wyrażenie regularne zawiera grupę przechwytywania „(...)”, zostanie użyta wartość grupy.</string>
     <string name="custom_template">Własny szablon</string>
     <string name="custom_templ_desc">Umożliwia ustawienie niestandardowego szablonu</string>
-    <string name="custom_templ_desc_long">Upewnij się, że ustawiłeś opcję \'Ekstra klawisze\' na \'Własny szablon\'.\n\n
+    <string name="custom_templ_desc_long" formatted="false">Upewnij się, że ustawiłeś opcję \'Ekstra klawisze\' na \'Własny szablon\'.\n\n
         Placeholdery CODE:\n
-        • {CODE} - zwykły kod kreskowy\n
+        • {CODE} - zwykła wartość kodu kreskowego\n
+        • {CODE%N} - N-ta grupa przechwytująca regex (np. {CODE%1}, {CODE%2}); wraca do {CODE} jeśli grupa nie istnieje lub nie ustawiono wyrażenia regularnego\n
         • Kodowanie: _HEX, _B64 można łączyć w dowolnej kolejności\n
         • Przykłady: {CODE_HEX}, {CODE_B64}, {CODE_HEX_B64}, {HEX_B64_CODE}\n\n
         Placeholdery daty/czasu z opcjonalnym formatowaniem:\n
@@ -213,6 +214,7 @@
     <string name="camera_error">Błąd aparatu!</string>
     <string name="camera_error_desc">Błąd inicjalizacji kamery. Uruchom ponownie aplikację lub urządzenie. Jeśli problem będzie się powtarzał, utwórz nowe zgłoszenie w serwisie Github.</string>
     <string name="press_run_to_evaluate">Naciśnij przycisk uruchom, aby przetestować</string>
+    <string name="js_error">Błąd JS: %s</string>
     <string name="custom_javascript">Niestandardowy JavaScript</string>
     <string name="custom_js_desc">Zmodyfikuj zeskanowaną wartość za pomocą JS</string>
     <string name="editor_desc">Umożliwia wprowadzenie dowolnego kodu JavaScript w celu zmodyfikowania wartości kodu. Zdefiniowane są dwie stałe (\'format\' i \'code\'). Ostatnia instrukcja jest używana jako wynik (ENTER nie jest wymagany).</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -147,9 +147,10 @@
     <string name="filter_desc_long">支持常见的正则表达式语法。使用空字符串或 .* 来匹配所有内容。如果正则表达式包含捕获组\"(…)\"，则将使用该组的值。</string>
     <string name="custom_template">自定义模板</string>
     <string name="custom_templ_desc">允许您设置自定义模板</string>
-    <string name="custom_templ_desc_long">请确保将\"附加按键\"设置为\"自定义\"。\n\n
+    <string name="custom_templ_desc_long" formatted="false">请确保将\"附加按键\"设置为\"自定义\"。\n\n
         代码占位符：\n
         • {CODE} - 纯条码值\n
+        • {CODE%N} - 第N个正则捕获组（例如 {CODE%1}、{CODE%2}）；若该组不存在或未设置正则表达式则回退到 {CODE}\n
         • 编码: _HEX, _B64 可以任意顺序组合\n
         • 示例: {CODE_HEX}, {CODE_B64}, {CODE_HEX_B64}, {HEX_B64_CODE}\n\n
         Date/Time 占位符（支持可选格式）：\n
@@ -222,6 +223,7 @@
     <string name="camera_error">相机错误！</string>
     <string name="camera_error_desc">初始化相机时出错。请重启应用或设备。如果问题持续，请在Github上提交新问题。</string>
     <string name="press_run_to_evaluate">按运行进行评估</string>
+    <string name="js_error">JS 错误：%s</string>
     <string name="custom_javascript">自定义JavaScript</string>
     <string name="custom_js_desc">使用JavaScript修改扫描值</string>
     <string name="editor_desc">允许您输入任何JavaScript来修改码的值。定义了两个常量（\'format\' 和 \'code\'）。最后一条语句将作为结果（不需要return）。</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -216,6 +216,7 @@
     <string name="press_run_to_evaluate">Press run to evaluate</string>
     <string name="custom_javascript">Custom JavaScript</string>
     <string name="custom_js_desc">Modify the scanned value using JS</string>
+    <string name="js_error">JS error: %s</string>
     <string name="editor_desc">Allows you to enter any JavaScript to modify the value of the code. Two constants are defined (\'format\' and \'code\'). Last statement is used as result (no return required).</string>
     <string name="editor">Editor</string>
     <string name="debug">Debug</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -139,9 +139,10 @@
     <string name="filter_desc_long">Supports common regex syntax. Use empty string or .* to match everything. If the regex contains a capture group "(…)", the value of the group will be used.</string>
     <string name="custom_template">Custom template</string>
     <string name="custom_templ_desc">Allows you to set a custom template</string>
-    <string name="custom_templ_desc_long">Make sure to set \'Extra keys\' to \'Custom\'.\n\n
+    <string name="custom_templ_desc_long" formatted="false">Make sure to set \'Extra keys\' to \'Custom\'.\n\n
         CODE placeholders:\n
-        • {CODE} - plain barcode\n
+        • {CODE} - plain barcode value\n
+        • {CODE%N} - Nth regex capture group (e.g. {CODE%1}, {CODE%2}); falls back to {CODE} if the group doesn\'t exist or no regex is set\n
         • Encoding: _HEX, _B64 can be combined in any order\n
         • Examples: {CODE_HEX}, {CODE_B64}, {CODE_HEX_B64}, {HEX_B64_CODE}\n\n
         Date/Time placeholders with optional formatting:\n

--- a/app/src/test/java/dev/fabik/bluetoothhid/utils/TemplateProcessorTest.kt
+++ b/app/src/test/java/dev/fabik/bluetoothhid/utils/TemplateProcessorTest.kt
@@ -199,4 +199,90 @@ class TemplateProcessorTest {
         )
         assertEquals("test", result)
     }
+
+    // --- {CODE%N} regex capture group tests ---
+
+    @Test
+    fun testRegexGroupFirst() {
+        // {CODE%1} should return first capture group
+        val result = TemplateProcessor.processTemplate(
+            data = "ABC",
+            template = "{CODE%1}",
+            mode = TemplateProcessor.TemplateMode.HID,
+            regexGroups = listOf("ABC", "123")
+        )
+        assertEquals("ABC", result)
+    }
+
+    @Test
+    fun testRegexGroupSecond() {
+        // {CODE%2} should return second capture group
+        val result = TemplateProcessor.processTemplate(
+            data = "ABC",
+            template = "{CODE%2}",
+            mode = TemplateProcessor.TemplateMode.HID,
+            regexGroups = listOf("ABC", "123")
+        )
+        assertEquals("123", result)
+    }
+
+    @Test
+    fun testRegexGroupMixedWithCode() {
+        // {CODE} and {CODE%N} can be used together
+        val result = TemplateProcessor.processTemplate(
+            data = "ABC",
+            template = "{CODE} / {CODE%2}",
+            mode = TemplateProcessor.TemplateMode.HID,
+            regexGroups = listOf("ABC", "123")
+        )
+        assertEquals("ABC / 123", result)
+    }
+
+    @Test
+    fun testRegexGroupOutOfRange() {
+        // {CODE%5} when only 2 groups exist → fallback to data
+        val result = TemplateProcessor.processTemplate(
+            data = "ABC",
+            template = "{CODE%5}",
+            mode = TemplateProcessor.TemplateMode.HID,
+            regexGroups = listOf("ABC", "123")
+        )
+        assertEquals("ABC", result)
+    }
+
+    @Test
+    fun testRegexGroupNoGroups() {
+        // {CODE%1} when no groups provided → fallback to data
+        val result = TemplateProcessor.processTemplate(
+            data = "ABC",
+            template = "{CODE%1}",
+            mode = TemplateProcessor.TemplateMode.HID,
+            regexGroups = emptyList()
+        )
+        assertEquals("ABC", result)
+    }
+
+    @Test
+    fun testRegexGroupValidationAcceptsCodeN() {
+        // Template with only {CODE%N} should pass validation (not return raw data)
+        val result = TemplateProcessor.processTemplate(
+            data = "fallback",
+            template = "{CODE%2}",
+            mode = TemplateProcessor.TemplateMode.HID,
+            regexGroups = listOf("part1", "part2")
+        )
+        assertEquals("part2", result)
+    }
+
+    @Test
+    fun testRegexGroupRFCOMM() {
+        // {CODE%N} works in RFCOMM mode too
+        val result = TemplateProcessor.processTemplate(
+            data = "full",
+            template = "A:{CODE%1} B:{CODE%2}{ENTER}",
+            mode = TemplateProcessor.TemplateMode.RFCOMM,
+            regexGroups = listOf("hello", "world")
+        )
+        assertEquals("A:hello B:world\r\n", result)
+    }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -24,4 +24,4 @@ kotlin.code.style=official
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
 android.enableR8.fullMode=true
-android.nonFinalResIds=false
+android.nonFinalResIds=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,9 +11,7 @@ org.gradle.unsafe.configuration-cache=true
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
-org.gradle.parallel=true
-org.gradle.caching=true
-kotlin.incremental=true
+# org.gradle.parallel=true
 # AndroidX package structure to make it clearer which packages are bundled with the
 # Android operating system, and which are packaged with your app's APK
 # https://developer.android.com/topic/libraries/support-library/androidx-rn

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,7 +11,9 @@ org.gradle.unsafe.configuration-cache=true
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
-# org.gradle.parallel=true
+org.gradle.parallel=true
+org.gradle.caching=true
+kotlin.incremental=true
 # AndroidX package structure to make it clearer which packages are bundled with the
 # Android operating system, and which are packaged with your app's APK
 # https://developer.android.com/topic/libraries/support-library/androidx-rn


### PR DESCRIPTION
Fixes the Node.js 20 deprecation warnings reported in #527.

Changes:
 - actions/checkout: v3 → v6
 - actions/setup-java: v3 → v5
 - actions/upload-artifact: v4 → v7
 - softprops/action-gh-release: v1 → v3
 - actions/stale: v8 → v10
 - dependabot: added github-actions ecosystem to auto-monitor future updates
 - test.yml: added .github/workflows/** to path triggers so CI runs on workflow changes
 
 ---------------
Regex capture groups in custom template – closes #192
Access specific regex capture groups in the output template using {CODE%N} syntax (e.g. {CODE%2} for the second group). Falls back to the full match if the group doesn't exist. {CODE} behavior is unchanged.

JavaScript editor improvements – closes #516, closes #517
- Input assistance (#517): auto-pairs ", ', (), [], {}; inserts new line with indentation after ;; preserves indentation on Enter
- Error feedback (#516): shows a Snackbar with the error message when JS evaluation fails, instead of silently falling back to the original value

Build time optimization from 4min+ -> 2min+