### PR TITLE
Fix Bluetooth reconnect (#486), add Cancel & Undo send (#259, #134), fix expandCode + countTypedChars bugs

### DIFF
--- a/app/src/main/java/dev/fabik/bluetoothhid/Scanner.kt
+++ b/app/src/main/java/dev/fabik/bluetoothhid/Scanner.kt
@@ -45,6 +45,8 @@ import androidx.compose.foundation.text.input.rememberTextFieldState
 import androidx.compose.foundation.text.input.selectAll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.Send
+import androidx.compose.material.icons.automirrored.filled.Undo
+import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.FlashOff
 import androidx.compose.material.icons.filled.FlashOn
 import androidx.compose.material.icons.filled.History
@@ -55,6 +57,7 @@ import androidx.compose.material3.ElevatedCard
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExtendedFloatingActionButton
 import androidx.compose.material3.FabPosition
+import androidx.compose.material3.SmallFloatingActionButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -582,8 +585,11 @@ private fun VolumeKeyHandler(onPress: (Int) -> Boolean) {
 }
 
 /**
- * Floating action button to send the current barcode to the connected device.
- * If the currentBarcode is null, the button is hidden.
+ * Floating action button area to send the current barcode to the connected device.
+ *
+ * - Normal state: Send FAB. If [enableUndoSend] is enabled and there is a last sent value,
+ *   a small Undo button is shown to the left of the Send FAB.
+ * - Sending state: Cancel FAB that stops the current transmission.
  *
  * @param onClick callback to send text to the current device
  */
@@ -591,31 +597,50 @@ private fun VolumeKeyHandler(onPress: (Int) -> Boolean) {
 @Composable
 private fun SendToDeviceFAB(onClick: () -> Unit) {
     val controller = LocalController.current
+    val context = LocalContext.current
+    val scope = rememberCoroutineScope()
 
     controller?.let {
-        val colorScheme = MaterialTheme.colorScheme
         val isSending by controller.isSending.collectAsStateWithLifecycle()
+        val lastSentCharCount by controller.lastSentCharCount.collectAsStateWithLifecycle()
+        val enableUndoSend by context.getPreferenceStateDefault(PreferenceStore.ENABLE_UNDO_SEND)
+        val connectionMode by context.getPreferenceState(PreferenceStore.CONNECTION_MODE)
+        val isHidMode = connectionMode != ConnectionMode.RFCOMM.ordinal
 
-        val (containerColor, contentColor) = remember(isSending) {
-            if (isSending) {
-                colorScheme.surface.copy(alpha = 0.12f) to
-                        colorScheme.onSurface.copy(alpha = 0.32f)
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            // Undo button: HID mode only — visible when undo is enabled and a completed send exists
+            if (isHidMode && !isSending && enableUndoSend && lastSentCharCount != null) {
+                SmallFloatingActionButton(
+                    onClick = { scope.launch { controller.undoLastSent() } },
+                    containerColor = MaterialTheme.colorScheme.secondaryContainer,
+                    contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
+                ) {
+                    Icon(Icons.AutoMirrored.Filled.Undo, stringResource(R.string.undo_last_sent))
+                }
+            }
+
+            if (isHidMode && isSending) {
+                // Cancel button: HID mode only — stops the current transmission
+                ExtendedFloatingActionButton(
+                    text = { Text(stringResource(R.string.cancel)) },
+                    icon = { Icon(Icons.Default.Close, stringResource(R.string.cancel)) },
+                    containerColor = MaterialTheme.colorScheme.errorContainer,
+                    contentColor = MaterialTheme.colorScheme.onErrorContainer,
+                    onClick = { controller.cancelSending() }
+                )
             } else {
-                colorScheme.primary to colorScheme.onPrimary
+                ExtendedFloatingActionButton(
+                    text = { Text(stringResource(R.string.send_to_device)) },
+                    icon = { Icon(Icons.AutoMirrored.Filled.Send, "Send") },
+                    containerColor = MaterialTheme.colorScheme.primary,
+                    contentColor = MaterialTheme.colorScheme.onPrimary,
+                    onClick = onClick
+                )
             }
         }
-
-        ExtendedFloatingActionButton(
-            text = {
-                Text(stringResource(R.string.send_to_device))
-            },
-            icon = {
-                Icon(Icons.AutoMirrored.Filled.Send, "Send")
-            },
-            contentColor = contentColor,
-            containerColor = containerColor,
-            onClick = { if (!isSending) onClick() }
-        )
     }
 }
 

--- a/app/src/main/java/dev/fabik/bluetoothhid/Settings.kt
+++ b/app/src/main/java/dev/fabik/bluetoothhid/Settings.kt
@@ -16,6 +16,7 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.Send
+import androidx.compose.material.icons.automirrored.filled.Undo
 import androidx.compose.material.icons.automirrored.filled.VolumeUp
 import androidx.compose.material.icons.filled.AddCircle
 import androidx.compose.material.icons.filled.AutoAwesome
@@ -411,6 +412,8 @@ internal fun CameraSettings(strings: SettingsStrings) {
 internal fun ScannerSettings(strings: SettingsStrings) {
     val context = LocalContext.current
     val scope = rememberCoroutineScope()
+    val connectionMode by rememberEnumPreference(PreferenceStore.CONNECTION_MODE)
+    val isHidMode = connectionMode != ConnectionMode.RFCOMM
 
     CheckBoxPreference(
         title = strings[R.string.code_types],
@@ -536,6 +539,14 @@ internal fun ScannerSettings(strings: SettingsStrings) {
         desc = strings[R.string.clear_after_send_desc],
         icon = Icons.Default.Clear,
         preference = PreferenceStore.CLEAR_AFTER_SEND
+    )
+
+    SwitchPreference(
+        title = strings[R.string.enable_undo_send],
+        desc = strings[R.string.enable_undo_send_desc],
+        icon = Icons.AutoMirrored.Filled.Undo,
+        enabled = isHidMode,
+        preference = PreferenceStore.ENABLE_UNDO_SEND
     )
 
     ComboBoxEnumPreference(

--- a/app/src/main/java/dev/fabik/bluetoothhid/bt/BluetoothController.kt
+++ b/app/src/main/java/dev/fabik/bluetoothhid/bt/BluetoothController.kt
@@ -75,6 +75,11 @@ class BluetoothController(var context: Context) {
     private var _isSending: MutableStateFlow<Boolean> = MutableStateFlow(false)
     val isSending = _isSending.asStateFlow()
 
+    // Number of typed characters from the last completed HID send — used for precise undo.
+    // Null means no completed send is available for undo (or last send was cancelled).
+    private var _lastSentCharCount: MutableStateFlow<Int?> = MutableStateFlow(null)
+    val lastSentCharCount = _lastSentCharCount.asStateFlow()
+
     private var _isCapsLockOn: MutableStateFlow<Boolean> = MutableStateFlow(false)
     val isCapsLockOn = _isCapsLockOn.asStateFlow()
 
@@ -112,6 +117,12 @@ class BluetoothController(var context: Context) {
                     PreferenceStore.QOS_DELAY_VARIATION.extract(it)
                 )
             }
+
+            // Clean up any stale HID app registration from a previous process instance.
+            // This can happen on Android 12+ when the OS kills the service without calling
+            // onDestroy, leaving the Bluetooth stack with an orphaned HID registration.
+            // Toggling Bluetooth (which clears the stack) was the only workaround before this fix.
+            hidDevice?.unregisterApp()
 
             hidDevice?.registerApp(
                 Descriptor.SDP_RECORD,
@@ -454,6 +465,40 @@ class BluetoothController(var context: Context) {
         }
     }
 
+    /**
+     * Cancel the currently running send operation (HID mode only).
+     * The keyboard sender will stop after the current key and send a release report (0,0)
+     * to avoid stuck keys on the host.
+     *
+     * Not applicable to RFCOMM mode: in RFCOMM the value is sent as a raw string directly
+     * into the stream in one shot, so there is nothing to interrupt by the time the UI reacts.
+     */
+    fun cancelSending() {
+        if (currentConnectionMode != ConnectionMode.HID) return
+        Log.d(TAG, "cancelSending")
+        keyboardSender?.requestCancel()
+    }
+
+    /**
+     * Undo the last sent value by transmitting one backspace per character (HID mode only).
+     * Clears [lastSentString] afterwards so double-undo is not possible.
+     *
+     * Not applicable to RFCOMM mode: backspace has no defined meaning in a raw byte stream —
+     * the receiving application would need to interpret it, which is not guaranteed.
+     */
+    suspend fun undoLastSent() {
+        if (currentConnectionMode != ConnectionMode.HID) return
+        val count = _lastSentCharCount.value ?: return
+        if (!_isSending.compareAndSet(expect = false, update = true)) return
+        try {
+            Log.d(TAG, "undoLastSent: $count backspaces")
+            keyboardSender?.sendBackspaces(count)
+            _lastSentCharCount.update { null }
+        } finally {
+            _isSending.update { false }
+        }
+    }
+
     fun disconnect(): Boolean {
         if (_isSending.value) {
             return false
@@ -521,7 +566,12 @@ class BluetoothController(var context: Context) {
             )
             rfcommController.sendProcessedData(processedString)
         } else {
-            // HID mode - process template for HID conversion
+            // HID mode - process template for HID conversion.
+            // expandCode controls whether HID template tokens inside the barcode value (e.g.
+            // "{ENTER}" embedded in the scanned data) are expanded as real keypresses (true)
+            // or typed as literal text (false, the default).  This is handled entirely inside
+            // TemplateProcessor by escaping { } in the barcode value when expandCode=false;
+            // KeyboardSender no longer needs to know about it.
             val processedString = TemplateProcessor.processTemplate(
                 string,
                 template,
@@ -530,17 +580,18 @@ class BluetoothController(var context: Context) {
                 scanTimestamp,
                 scannerID,
                 barcodeType,
-                false,  // HID always false - placeholders needed for KeyTranslator
-                imageName,
-                regexGroups
+                preserveUnsupportedPlaceholders = false,  // HID: pass all placeholders to KeyTranslator
+                scanImageFileName = imageName,
+                regexGroups = regexGroups,
+                expandCode = expand
             )
+            // Store the precise typed-character count for undo (null = cancelled, not stored)
             keyboardSender?.sendProcessedString(
                 processedString,
                 sendDelay.toLong(),
                 extraKeys,
-                layout.value,
-                expand
-            )
+                layout.value
+            )?.let { charCount -> _lastSentCharCount.update { charCount } }
         }
 
         _isSending.update { false }

--- a/app/src/main/java/dev/fabik/bluetoothhid/bt/BluetoothController.kt
+++ b/app/src/main/java/dev/fabik/bluetoothhid/bt/BluetoothController.kt
@@ -493,8 +493,10 @@ class BluetoothController(var context: Context) {
         try {
             Log.d(TAG, "undoLastSent: $count backspaces")
             keyboardSender?.sendBackspaces(count)
-            _lastSentCharCount.update { null }
         } finally {
+            // Clear the count and release the lock regardless of whether sendBackspaces throws.
+            // Clearing in finally prevents a double-undo if the BT send fails mid-way.
+            _lastSentCharCount.update { null }
             _isSending.update { false }
         }
     }
@@ -530,71 +532,76 @@ class BluetoothController(var context: Context) {
             return@with
         }
 
-        val sendDelay = PreferenceStore.SEND_DELAY.extract(preferences)
-        val extraKeys =
-            if (!withExtraKeys) ExtraKeys.NONE
-            else PreferenceStore.EXTRA_KEYS.extractEnum(preferences)
-        val layout = PreferenceStore.KEYBOARD_LAYOUT.extractEnum(preferences)
-        val template =
-            if (!withExtraKeys || extraKeys != ExtraKeys.CUSTOM) ""
-            else PreferenceStore.TEMPLATE_TEXT.extract(preferences)
-        val expand =
-            if (!withExtraKeys || extraKeys != ExtraKeys.CUSTOM) false
-            else PreferenceStore.EXPAND_CODE.extract(preferences)
+        try {
+            val sendDelay = PreferenceStore.SEND_DELAY.extract(preferences)
+            val extraKeys =
+                if (!withExtraKeys) ExtraKeys.NONE
+                else PreferenceStore.EXTRA_KEYS.extractEnum(preferences)
+            val layout = PreferenceStore.KEYBOARD_LAYOUT.extractEnum(preferences)
+            val template =
+                if (!withExtraKeys || extraKeys != ExtraKeys.CUSTOM) ""
+                else PreferenceStore.TEMPLATE_TEXT.extract(preferences)
+            val expand =
+                if (!withExtraKeys || extraKeys != ExtraKeys.CUSTOM) false
+                else PreferenceStore.EXPAND_CODE.extract(preferences)
 
-        // Get scanner ID
-        val scannerID = getScannerID()
+            // Get scanner ID
+            val scannerID = getScannerID()
 
-        // Get preserve unsupported placeholders preference (RFCOMM only)
-        val preserveUnsupported =
-            PreferenceStore.PRESERVE_UNSUPPORTED_PLACEHOLDERS.extract(preferences)
+            // Get preserve unsupported placeholders preference (RFCOMM only)
+            val preserveUnsupported =
+                PreferenceStore.PRESERVE_UNSUPPORTED_PLACEHOLDERS.extract(preferences)
 
-        // Check connection mode - RFCOMM or HID using cached value
-        if (currentConnectionMode == ConnectionMode.RFCOMM) {
-            // RFCOMM mode - process template for text output
-            val processedString = TemplateProcessor.processTemplate(
-                string,
-                template,
-                TemplateProcessor.TemplateMode.RFCOMM,
-                from,
-                scanTimestamp,
-                scannerID,
-                barcodeType,
-                preserveUnsupported,  // Pass preference
-                imageName,
-                regexGroups
-            )
-            rfcommController.sendProcessedData(processedString)
-        } else {
-            // HID mode - process template for HID conversion.
-            // expandCode controls whether HID template tokens inside the barcode value (e.g.
-            // "{ENTER}" embedded in the scanned data) are expanded as real keypresses (true)
-            // or typed as literal text (false, the default).  This is handled entirely inside
-            // TemplateProcessor by escaping { } in the barcode value when expandCode=false;
-            // KeyboardSender no longer needs to know about it.
-            val processedString = TemplateProcessor.processTemplate(
-                string,
-                template,
-                TemplateProcessor.TemplateMode.HID,
-                from,
-                scanTimestamp,
-                scannerID,
-                barcodeType,
-                preserveUnsupportedPlaceholders = false,  // HID: pass all placeholders to KeyTranslator
-                scanImageFileName = imageName,
-                regexGroups = regexGroups,
-                expandCode = expand
-            )
-            // Store the precise typed-character count for undo (null = cancelled, not stored)
-            keyboardSender?.sendProcessedString(
-                processedString,
-                sendDelay.toLong(),
-                extraKeys,
-                layout.value
-            )?.let { charCount -> _lastSentCharCount.update { charCount } }
+            // Check connection mode - RFCOMM or HID using cached value
+            if (currentConnectionMode == ConnectionMode.RFCOMM) {
+                // RFCOMM mode - process template for text output
+                val processedString = TemplateProcessor.processTemplate(
+                    string,
+                    template,
+                    TemplateProcessor.TemplateMode.RFCOMM,
+                    from,
+                    scanTimestamp,
+                    scannerID,
+                    barcodeType,
+                    preserveUnsupported,  // Pass preference
+                    imageName,
+                    regexGroups
+                )
+                rfcommController.sendProcessedData(processedString)
+            } else {
+                // HID mode - process template for HID conversion.
+                // expandCode controls whether HID template tokens inside the barcode value (e.g.
+                // "{ENTER}" embedded in the scanned data) are expanded as real keypresses (true)
+                // or typed as literal text (false, the default).  This is handled entirely inside
+                // TemplateProcessor by escaping { } in the barcode value when expandCode=false;
+                // KeyboardSender no longer needs to know about it.
+                val processedString = TemplateProcessor.processTemplate(
+                    string,
+                    template,
+                    TemplateProcessor.TemplateMode.HID,
+                    from,
+                    scanTimestamp,
+                    scannerID,
+                    barcodeType,
+                    preserveUnsupportedPlaceholders = false,  // HID: pass all placeholders to KeyTranslator
+                    scanImageFileName = imageName,
+                    regexGroups = regexGroups,
+                    expandCode = expand
+                )
+                // Store the precise typed-character count for undo (null = cancelled, not stored)
+                keyboardSender?.sendProcessedString(
+                    processedString,
+                    sendDelay.toLong(),
+                    extraKeys,
+                    layout.value
+                )?.let { charCount -> _lastSentCharCount.update { charCount } }
+            }
+        } finally {
+            // Always release the sending lock — even if processTemplate or sendProcessedString
+            // throws (e.g. SecurityException from BluetoothHidDevice.sendReport).
+            // Without this, _isSending stays true and the app is permanently blocked.
+            _isSending.update { false }
         }
-
-        _isSending.update { false }
     }
 }
 

--- a/app/src/main/java/dev/fabik/bluetoothhid/bt/KeyTranslator.kt
+++ b/app/src/main/java/dev/fabik/bluetoothhid/bt/KeyTranslator.kt
@@ -44,6 +44,9 @@ class KeyTranslator(context: Context) {
         val CAPS_LOCK_KEY = Key(0u, 0x39u)
         val BACKSPACE_KEY = Key(0u, 0x2Au)
 
+        /** Matches HID template tokens such as `{ENTER}`, `{+F1}`, `{WAIT:500}`. */
+        private val HID_TEMPLATE_REGEX = Regex("\\{([+^#@]*[\\w:]+)\\}")
+
         private const val CUSTOM_KEYMAP_FILE = "custom.layout"
         private var customKeyMapLoaded = false
         var CUSTOM_KEYMAP = mutableMapOf<Char, Pair<Key, Key?>>()
@@ -204,42 +207,43 @@ class KeyTranslator(context: Context) {
      * (when `expandCode = false`) back to their original `{` / `}` characters.
      *
      * This is called on the plain-text segments *between* HID template matches inside
-     * [translateStringWithTemplate], so that literal braces originating from barcode data are
-     * typed as real characters rather than remaining as unrecognised codepoints.
+     * [translateStringWithTemplateDetailed], so that literal braces originating from barcode
+     * data are typed as real characters rather than remaining as unrecognised codepoints.
      */
     private fun restoreEscapedBraces(text: String): String =
         text.replace(ESCAPED_OPEN_BRACE, '{').replace(ESCAPED_CLOSE_BRACE, '}')
 
-    // Translates a string into a list of keys using a template string
-    // Note: Basic templates (CODE, DATE, TIME, etc.) should be processed by TemplateProcessor first
-    fun translateStringWithTemplate(
+    /**
+     * Translates [processedString] — which may contain HID template tokens such as `{ENTER}`,
+     * `{F1}`, `{WAIT:ms}`, etc. — into a list of HID key events.  Each event carries a flag
+     * indicating whether it completes a visible character on the host, used by
+     * [dev.fabik.bluetoothhid.bt.KeyboardSender] to track the exact typed-character count
+     * in-loop (including after a partial cancel).
+     *
+     * Basic templates (`{CODE}`, `{DATE}`, `{TIME}`, …) must be substituted by
+     * [dev.fabik.bluetoothhid.utils.TemplateProcessor] before this method is called.
+     */
+    fun translateStringWithTemplateDetailed(
         processedString: String,
         locale: String,
-        expandedCode: List<Key>? = null
-    ): List<Key> {
-        val keys = mutableListOf<Key>()
-        val templateRegex = Regex("\\{([+^#@]*[\\w:]+)\\}")
+    ): List<Pair<Key, Boolean>> {
+        val result = mutableListOf<Pair<Key, Boolean>>()
 
         var startIdx = 0
-        templateRegex.findAll(processedString).forEach {
+        HID_TEMPLATE_REGEX.findAll(processedString).forEach {
             // Adds everything before the template, restoring any escaped braces that came
             // from barcode data (expandCode=false path in TemplateProcessor).
             val before = restoreEscapedBraces(processedString.substring(startIdx, it.range.first))
-            keys.addAll(translateString(before, locale))
+            result.addAll(translateStringDetailed(before, locale))
 
             // Process HID-specific template
             val template = it.groupValues[1]
             if (template.startsWith("CODE")) {
-                // Handle expandedCode mechanism (for complex template processing)
-                if (expandedCode != null) {
-                    keys.addAll(expandedCode)
-                } else {
-                    // This shouldn't happen if TemplateProcessor handled basic templates
-                    Log.w(TAG, "CODE template found in processed string: $template")
-                    keys.addAll(translateString(template, locale))
-                }
+                // {CODE} should always be substituted by TemplateProcessor before reaching here.
+                Log.w(TAG, "Unsubstituted CODE template in processed string — typing literally")
+                result.addAll(translateStringDetailed(template, locale))
             } else {
-                processHidSpecificTemplate(template, locale, keys)
+                result.addAll(processHidSpecificTemplateDetailed(template, locale))
             }
 
             startIdx = it.range.last + 1
@@ -247,17 +251,17 @@ class KeyTranslator(context: Context) {
 
         // Adds the rest of the template, also restoring any trailing escaped braces.
         val after = restoreEscapedBraces(processedString.substring(startIdx))
-        keys.addAll(translateString(after, locale))
+        result.addAll(translateStringDetailed(after, locale))
 
-        return keys
+        return result
     }
 
     // Process HID-specific templates (modifiers, F-keys, arrows, etc.)
-    private fun processHidSpecificTemplate(
+    private fun processHidSpecificTemplateDetailed(
         template: String,
-        locale: String,
-        keys: MutableList<Key>
-    ) {
+        locale: String
+    ): List<Pair<Key, Boolean>> {
+        val result = mutableListOf<Pair<Key, Boolean>>()
         var modifiers = 0.toUByte()
         var temp = template
         var wasModifier = true
@@ -276,69 +280,78 @@ class KeyTranslator(context: Context) {
             }
         } while (wasModifier)
 
+        if (temp.isEmpty()) {
+            Log.w(TAG, "Malformed HID template: modifier(s) with no key name (original: '$template')")
+            return result
+        }
+
         if (temp.isNotEmpty()) {
             Log.d(TAG, "HID template: $temp, modifiers: $modifiers")
 
             staticTemplates[temp]?.let { t ->
-                keys.add(t.first or modifiers to t.second)
+                // A static template key produces a visible character only when sent without
+                // extra modifiers.  {+ENTER} (Ctrl+Enter) is a control combo, not visible text.
+                result.add(Key(t.first or modifiers, t.second) to (isTextProducingKeycode(t.second) && modifiers == 0.toUByte()))
             } ?: dynamicTemplates[temp.substringBefore(':')]?.let { t ->
-                keys.addAll(t(locale, temp.substringAfter(':', "")))
-            } ?: translateString(temp, locale).forEach { t ->
-                keys.add(Key(t.first or modifiers, t.second))
+                t(locale, temp.substringAfter(':', "")).forEach { key ->
+                    result.add(key to false) // dynamic templates (WAIT, etc.) produce no visible chars
+                }
+            } ?: run {
+                // Fallback: unknown template — treat as plain text with optional extra modifiers.
+                // Extra modifier flags (e.g. {+A} = Ctrl+A) turn it into a control combo → not visible.
+                val hasExtraModifiers = modifiers != 0.toUByte()
+                translateStringDetailed(temp, locale).forEach { (key, completesChar) ->
+                    result.add(Key(key.first or modifiers, key.second) to (completesChar && !hasExtraModifiers))
+                }
             }
         }
+        return result
     }
 
     /**
-     * Counts the number of characters that will actually appear as typed text on the host
-     * for a given [processedString] going through [translateStringWithTemplate].
-     *
-     * - Regular chars: each counts as 1 (dead-key sequences still produce one visible char).
-     * - Text-producing HID templates ({ENTER}, {TAB}, {BKSP}, {SPACE}): count as 1 each.
-     * - Non-text HID templates ({F1}–{F24}, {LEFT}, {RIGHT}, {UP}, {DOWN}, {ESC}, {WAIT}): 0.
+     * Translates [string] into HID key events.  Each event carries a flag indicating whether
+     * For dead-key sequences (e.g. `é` = dead-accent key + `e` key): the dead-accent key has
+     * `completesChar = false`; the following `e` key has `completesChar = true`.
+     * For regular single-key characters: `completesChar = true`.
      */
-    fun countTypedChars(processedString: String, locale: String): Int {
-        val templateRegex = Regex("\\{([+^#@]*[\\w:]+)\\}")
-        // Templates that produce exactly one typed character on the host
-        val textProducingTemplates = setOf("ENTER", "TAB", "BKSP", "SPACE")
-
-        var count = 0
-        var startIdx = 0
-
-        templateRegex.findAll(processedString).forEach { match ->
-            // Count plain chars before this template
-            count += processedString.substring(startIdx, match.range.first).length
-            // Count the template itself if it produces text
-            val templateName = match.groupValues[1].trimStart('+', '^', '#', '@')
-                .substringBefore(':')
-            if (templateName in textProducingTemplates || templateName.startsWith("CODE")) {
-                count += 1
-            }
-            // Non-text templates (Fx, arrows, ESC, WAIT, …) contribute 0
-            startIdx = match.range.last + 1
-        }
-
-        // Count remaining plain chars after last template
-        count += processedString.substring(startIdx).length
-
-        return count
-    }
-
-    // Converts a normal string into a list of keys
-    fun translateString(string: String, locale: String): List<Key> {
-        val keys = mutableListOf<Key>()
+    internal fun translateStringDetailed(string: String, locale: String): List<Pair<Key, Boolean>> {
+        val result = mutableListOf<Pair<Key, Boolean>>()
 
         Log.d(TAG, "Translating: '$string' with locale '$locale'")
 
         string.forEach { chr ->
             translate(chr, locale)?.let { (key, dkey) ->
-                keys.add(key)
-                dkey?.let { keys.add(it) }
+                if (dkey != null) {
+                    result.add(key to false)  // dead key prefix — does not yet complete a char
+                    result.add(dkey to true)  // second key completes the visible character
+                } else {
+                    result.add(key to true)
+                }
             } ?: Log.w(TAG, "Unknown char: $chr (${chr.code})")
         }
 
-        return keys
+        return result
     }
+
+    /**
+     * Returns true if [keycode] adds a visible character on the host, meaning exactly one
+     * backspace is needed to undo it.  HID keycodes 0x04–0x38 cover all such keys: printable
+     * characters (letters, digits, punctuation), Space (0x2C), Tab (0x2B), and Enter (0x28).
+     *
+     * Explicitly excluded from the range:
+     * - ESC (0x29): no visible effect.
+     * - Backspace (0x2A): *removes* a character rather than adding one.  Counting it as a
+     *   visible char would cause undo to send one extra backspace per {BKSP} in the template,
+     *   deleting a character the user never typed.
+     *
+     * Note: this function only inspects the keycode.  Callers must additionally check that no
+     * modifier flags are set — a key combined with Ctrl/Alt/Meta becomes a control combo that
+     * produces no visible character (e.g. Ctrl+Enter, Ctrl+Tab).
+     */
+    private fun isTextProducingKeycode(keycode: UByte): Boolean =
+        keycode.toInt() in 0x04..0x38
+            && keycode != 0x29.toUByte()   // ESC
+            && keycode != 0x2A.toUByte()   // Backspace
 
     private fun translate(char: Char, locale: String): Pair<Key, Key?>? {
         val keymap = keyMaps[locale] ?: baseMap

--- a/app/src/main/java/dev/fabik/bluetoothhid/bt/KeyTranslator.kt
+++ b/app/src/main/java/dev/fabik/bluetoothhid/bt/KeyTranslator.kt
@@ -3,6 +3,7 @@ package dev.fabik.bluetoothhid.bt
 import android.content.Context
 import android.content.res.AssetManager
 import android.util.Log
+import dev.fabik.bluetoothhid.utils.TemplateProcessor
 import java.util.Collections
 
 // Represents a key with its modifier and hid scan code
@@ -15,6 +16,17 @@ typealias Keymap = Map<Char, Pair<Key, Key?>>
 class KeyTranslator(context: Context) {
     companion object {
         private const val TAG = "KeyTranslator"
+
+        /**
+         * Private Use Area sentinels written by [TemplateProcessor.escapeBracesForHID] when
+         * `expandCode = false`.  They mark literal `{` / `}` characters that originated from
+         * the scanned barcode value and must be decoded back to braces before keymap lookup,
+         * so that embedded HID template tokens are typed as text rather than executed.
+         *
+         * Must stay in sync with [TemplateProcessor.ESCAPED_OPEN_BRACE] / [TemplateProcessor.ESCAPED_CLOSE_BRACE].
+         */
+        private const val ESCAPED_OPEN_BRACE = TemplateProcessor.ESCAPED_OPEN_BRACE
+        private const val ESCAPED_CLOSE_BRACE = TemplateProcessor.ESCAPED_CLOSE_BRACE
 
         const val LCTRL: UByte = 0x01u
         const val LSHIFT: UByte = 0x02u
@@ -30,6 +42,7 @@ class KeyTranslator(context: Context) {
         private val RETURN = '\n' to (Key(0u, 0x28u) to null)
 
         val CAPS_LOCK_KEY = Key(0u, 0x39u)
+        val BACKSPACE_KEY = Key(0u, 0x2Au)
 
         private const val CUSTOM_KEYMAP_FILE = "custom.layout"
         private var customKeyMapLoaded = false
@@ -186,6 +199,17 @@ class KeyTranslator(context: Context) {
         }
     }
 
+    /**
+     * Restores Private Use Area brace sentinels introduced by [TemplateProcessor.escapeBracesForHID]
+     * (when `expandCode = false`) back to their original `{` / `}` characters.
+     *
+     * This is called on the plain-text segments *between* HID template matches inside
+     * [translateStringWithTemplate], so that literal braces originating from barcode data are
+     * typed as real characters rather than remaining as unrecognised codepoints.
+     */
+    private fun restoreEscapedBraces(text: String): String =
+        text.replace(ESCAPED_OPEN_BRACE, '{').replace(ESCAPED_CLOSE_BRACE, '}')
+
     // Translates a string into a list of keys using a template string
     // Note: Basic templates (CODE, DATE, TIME, etc.) should be processed by TemplateProcessor first
     fun translateStringWithTemplate(
@@ -198,8 +222,9 @@ class KeyTranslator(context: Context) {
 
         var startIdx = 0
         templateRegex.findAll(processedString).forEach {
-            // Adds everything before the template
-            val before = processedString.substring(startIdx, it.range.first)
+            // Adds everything before the template, restoring any escaped braces that came
+            // from barcode data (expandCode=false path in TemplateProcessor).
+            val before = restoreEscapedBraces(processedString.substring(startIdx, it.range.first))
             keys.addAll(translateString(before, locale))
 
             // Process HID-specific template
@@ -220,8 +245,8 @@ class KeyTranslator(context: Context) {
             startIdx = it.range.last + 1
         }
 
-        // Adds the rest of the template
-        val after = processedString.substring(startIdx)
+        // Adds the rest of the template, also restoring any trailing escaped braces.
+        val after = restoreEscapedBraces(processedString.substring(startIdx))
         keys.addAll(translateString(after, locale))
 
         return keys
@@ -262,6 +287,41 @@ class KeyTranslator(context: Context) {
                 keys.add(Key(t.first or modifiers, t.second))
             }
         }
+    }
+
+    /**
+     * Counts the number of characters that will actually appear as typed text on the host
+     * for a given [processedString] going through [translateStringWithTemplate].
+     *
+     * - Regular chars: each counts as 1 (dead-key sequences still produce one visible char).
+     * - Text-producing HID templates ({ENTER}, {TAB}, {BKSP}, {SPACE}): count as 1 each.
+     * - Non-text HID templates ({F1}–{F24}, {LEFT}, {RIGHT}, {UP}, {DOWN}, {ESC}, {WAIT}): 0.
+     */
+    fun countTypedChars(processedString: String, locale: String): Int {
+        val templateRegex = Regex("\\{([+^#@]*[\\w:]+)\\}")
+        // Templates that produce exactly one typed character on the host
+        val textProducingTemplates = setOf("ENTER", "TAB", "BKSP", "SPACE")
+
+        var count = 0
+        var startIdx = 0
+
+        templateRegex.findAll(processedString).forEach { match ->
+            // Count plain chars before this template
+            count += processedString.substring(startIdx, match.range.first).length
+            // Count the template itself if it produces text
+            val templateName = match.groupValues[1].trimStart('+', '^', '#', '@')
+                .substringBefore(':')
+            if (templateName in textProducingTemplates || templateName.startsWith("CODE")) {
+                count += 1
+            }
+            // Non-text templates (Fx, arrows, ESC, WAIT, …) contribute 0
+            startIdx = match.range.last + 1
+        }
+
+        // Count remaining plain chars after last template
+        count += processedString.substring(startIdx).length
+
+        return count
     }
 
     // Converts a normal string into a list of keys

--- a/app/src/main/java/dev/fabik/bluetoothhid/bt/KeyboardSender.kt
+++ b/app/src/main/java/dev/fabik/bluetoothhid/bt/KeyboardSender.kt
@@ -14,7 +14,7 @@ open class KeyboardSender(
     private val host: BluetoothDevice
 ) {
     companion object {
-        const val TAG = "KeyboardSender"
+        private const val TAG = "KeyboardSender"
     }
 
     private val report = ByteArray(3)
@@ -35,15 +35,21 @@ open class KeyboardSender(
 
     /**
      * Sends [processedString] as HID keystrokes and returns the number of characters that
-     * were actually typed on the host, or `null` if the send was cancelled before it finished.
+     * were actually typed on the host, or `null` if the send was cancelled before any visible
+     * character was typed.
      *
-     * The returned count is the number of backspaces required to fully undo the send:
-     * - For non-CUSTOM extra keys: equals [finalString].length — always exact, because each
-     *   character in the string maps to exactly one visible character on the host (dead-key
-     *   sequences take two keypresses but still produce one character = one backspace).
-     * - For CUSTOM extra keys: equals the number of non-template characters plus one per
-     *   text-producing HID template (e.g. {ENTER}, {TAB}). Pure control templates like
-     *   {F1} or {LEFT} produce no visible characters and are not counted.
+     * The returned count is the number of backspaces required to undo what was typed:
+     * - On full completion: total visible characters (letters, digits, Enter, Tab, Space, …).
+     *   Note: {BKSP} is intentionally excluded — it removes a character rather than adding one,
+     *   so counting it would send one extra backspace per {BKSP} and delete an unrelated char.
+     * - On cancel mid-send: visible characters typed so far — enables partial undo via
+     *   [sendBackspaces] when the send is interrupted.
+     * - On cancel before any visible character: `null` (nothing to undo).
+     *
+     * Character counting is performed in-loop using information from [KeyTranslator]:
+     * each translated key carries a flag indicating whether it completes a visible character
+     * on the host (dead-key prefix keys are flagged `false`; control combinations and
+     * non-text templates such as {F1} or {WAIT} are also flagged `false`).
      */
     suspend fun sendProcessedString(
         processedString: String,
@@ -55,26 +61,33 @@ open class KeyboardSender(
 
         val finalString = appendKey.suffix?.let { "$processedString$it" } ?: processedString
 
-        val (keys, charCount) = if (appendKey == ExtraKeys.CUSTOM) {
-            // TemplateProcessor has already handled both {CODE} substitution and the expandCode
-            // semantics: when expandCode=false, any HID template tokens embedded in the barcode
-            // value (e.g. "{ENTER}") were escaped with Private Use Area sentinels so that
-            // KeyTranslator types them as literal characters rather than executing them as
-            // keypresses.  A single pass through translateStringWithTemplate is therefore correct
-            // for both expandCode=true and expandCode=false; no two-pass mechanism is needed here.
-            keyboardTranslator.translateStringWithTemplate(finalString, locale)
-                .let { it to keyboardTranslator.countTypedChars(finalString, locale) }
-        } else {
-            // Non-CUSTOM: finalString is a plain string, length = exact undo char count
-            keyboardTranslator.translateString(finalString, locale) to finalString.length
-        }
+        // Always use translateStringWithTemplateDetailed, even for non-CUSTOM modes.
+        //
+        // Reason: TemplateProcessor may have escaped literal `{`/`}` characters in the barcode
+        // value with Private Use Area sentinels (U+E001/U+E002) when expandCode=false.
+        // translateStringDetailed does NOT know about those sentinels and would log "Unknown char"
+        // for every brace in the barcode.  translateStringWithTemplateDetailed calls
+        // restoreEscapedBraces() on every text segment, so the sentinels are decoded back to
+        // `{`/`}` before keymap lookup — regardless of whether the template contained HID tokens.
+        //
+        // For non-CUSTOM modes, finalString contains no unresolved `{…}` HID template tokens
+        // (TemplateProcessor already substituted them all), so the template-matching pass is a
+        // cheap no-op and correctness is preserved.
+        val keys: List<Pair<Key, Boolean>> =
+            keyboardTranslator.translateStringWithTemplateDetailed(finalString, locale)
+
+        var charCount = 0
 
         try {
-            for (key in keys) {
-                if (cancelRequested) return null
+            for ((key, completesChar) in keys) {
+                if (cancelRequested) return charCount.takeIf { it > 0 }
                 Log.d(TAG, "sendProcessedString: $key")
                 sendKey(key, sendDelay / 2)
-                if (cancelRequested) return null
+                // Increment immediately after sendKey so the count reflects what was actually
+                // transmitted — BluetoothHidDevice.sendReport is fire-and-forget, so by the
+                // time sendKey() returns the host has already received the report.
+                if (completesChar) charCount++
+                if (cancelRequested) return charCount.takeIf { it > 0 }
                 delay(sendDelay / 2)
             }
         } finally {

--- a/app/src/main/java/dev/fabik/bluetoothhid/bt/KeyboardSender.kt
+++ b/app/src/main/java/dev/fabik/bluetoothhid/bt/KeyboardSender.kt
@@ -19,40 +19,83 @@ open class KeyboardSender(
 
     private val report = ByteArray(3)
 
+    @Volatile
+    private var cancelRequested = false
+
+    /** Request cancellation of the currently running [sendProcessedString]. */
+    fun requestCancel() {
+        cancelRequested = true
+    }
+
     private fun sendReport(report: ByteArray) {
         if (!hidDevice.sendReport(host, Descriptor.ID, report)) {
             Log.e(TAG, "Error sending keyboard report")
         }
     }
 
+    /**
+     * Sends [processedString] as HID keystrokes and returns the number of characters that
+     * were actually typed on the host, or `null` if the send was cancelled before it finished.
+     *
+     * The returned count is the number of backspaces required to fully undo the send:
+     * - For non-CUSTOM extra keys: equals [finalString].length — always exact, because each
+     *   character in the string maps to exactly one visible character on the host (dead-key
+     *   sequences take two keypresses but still produce one character = one backspace).
+     * - For CUSTOM extra keys: equals the number of non-template characters plus one per
+     *   text-producing HID template (e.g. {ENTER}, {TAB}). Pure control templates like
+     *   {F1} or {LEFT} produce no visible characters and are not counted.
+     */
     suspend fun sendProcessedString(
         processedString: String,
         sendDelay: Long,
         appendKey: ExtraKeys,
         locale: String,
-        expandCode: Boolean,
-    ) {
+    ): Int? {
+        cancelRequested = false
+
         val finalString = appendKey.suffix?.let { "$processedString$it" } ?: processedString
 
-        val keys = if (appendKey == ExtraKeys.CUSTOM) {
-            if (expandCode) {
-                // Complex expandCode mechanism - treat processed string as template for expansion
-                val expandedCode = keyboardTranslator.translateStringWithTemplate(finalString, locale)
-                keyboardTranslator.translateStringWithTemplate("", locale, expandedCode)
-            } else {
-                // Simple template processing on the already processed string
-                keyboardTranslator.translateStringWithTemplate(finalString, locale)
-            }
+        val (keys, charCount) = if (appendKey == ExtraKeys.CUSTOM) {
+            // TemplateProcessor has already handled both {CODE} substitution and the expandCode
+            // semantics: when expandCode=false, any HID template tokens embedded in the barcode
+            // value (e.g. "{ENTER}") were escaped with Private Use Area sentinels so that
+            // KeyTranslator types them as literal characters rather than executing them as
+            // keypresses.  A single pass through translateStringWithTemplate is therefore correct
+            // for both expandCode=true and expandCode=false; no two-pass mechanism is needed here.
+            keyboardTranslator.translateStringWithTemplate(finalString, locale)
+                .let { it to keyboardTranslator.countTypedChars(finalString, locale) }
         } else {
-            keyboardTranslator.translateString(finalString, locale)
+            // Non-CUSTOM: finalString is a plain string, length = exact undo char count
+            keyboardTranslator.translateString(finalString, locale) to finalString.length
         }
 
-        keys.forEach { key ->
-            Log.d(TAG, "sendProcessedString: $key")
-            sendKey(key, sendDelay / 2)
-            delay(sendDelay / 2)
+        try {
+            for (key in keys) {
+                if (cancelRequested) return null
+                Log.d(TAG, "sendProcessedString: $key")
+                sendKey(key, sendDelay / 2)
+                if (cancelRequested) return null
+                delay(sendDelay / 2)
+            }
+        } finally {
+            // Always release all keys at the end, even if cancelled
+            sendKey(0, 0)
         }
-        // Send final release key (just to be sure)
+
+        return charCount
+    }
+
+    /**
+     * Send [count] backspace key presses to undo the last transmitted value.
+     * @param count number of backspaces to send (one per character of the original value)
+     */
+    suspend fun sendBackspaces(count: Int) {
+        Log.d(TAG, "sendBackspaces: $count")
+        repeat(count) {
+            sendKey(KeyTranslator.BACKSPACE_KEY, 10)
+            delay(10)
+        }
+        // Release all keys after backspaces
         sendKey(0, 0)
     }
 

--- a/app/src/main/java/dev/fabik/bluetoothhid/ui/Preference.kt
+++ b/app/src/main/java/dev/fabik/bluetoothhid/ui/Preference.kt
@@ -43,11 +43,12 @@ fun SwitchPreference(
     title: String,
     desc: String,
     icon: ImageVector? = null,
+    enabled: Boolean = true,
     preference: PreferenceStore.Preference<Boolean>
 ) {
     var checked by rememberPreferenceNull(preference)
 
-    SwitchPreference(title, desc, icon, checked) {
+    SwitchPreference(title, desc, icon, checked, enabled) {
         checked = it
     }
 }
@@ -58,6 +59,7 @@ fun SwitchPreference(
     desc: String,
     icon: ImageVector? = null,
     checked: Boolean?,
+    enabled: Boolean = true,
     onToggle: (Boolean) -> Unit
 ) {
     ButtonPreference(
@@ -65,10 +67,12 @@ fun SwitchPreference(
             checked?.let { c ->
                 Switch(
                     checked = c,
-                    onCheckedChange = null
+                    onCheckedChange = null,
+                    enabled = enabled
                 )
             }
-        }
+        },
+        enabled = enabled
     ) {
         checked?.let {
             onToggle(!it)

--- a/app/src/main/java/dev/fabik/bluetoothhid/utils/PreferenceStore.kt
+++ b/app/src/main/java/dev/fabik/bluetoothhid/utils/PreferenceStore.kt
@@ -263,6 +263,7 @@ open class PreferenceStore {
         val VIBRATE = booleanPreferencesKey("vibrate") defaultsTo false
         val AUTO_COPY_TO_CLIPBOARD = booleanPreferencesKey("auto_copy_to_clipboard") defaultsTo false
         val CLEAR_AFTER_SEND = booleanPreferencesKey("clear_after_send") defaultsTo false
+        val ENABLE_UNDO_SEND = booleanPreferencesKey("enable_undo_send") defaultsTo false
         val CLEAR_AFTER_TIME =
             intPreferencesKey("clear_after_time") enumDefaultsTo ClearAfterTime::fromIndex
 

--- a/app/src/main/java/dev/fabik/bluetoothhid/utils/TemplateProcessor.kt
+++ b/app/src/main/java/dev/fabik/bluetoothhid/utils/TemplateProcessor.kt
@@ -26,7 +26,7 @@ object TemplateProcessor {
      * Private Use Area sentinels used to escape literal `{` / `}` characters that originate
      * from barcode data when [expandCode] is false.  They are invisible to the HID template
      * regex in [KeyTranslator] (which only matches `{…}`) and are decoded back to `{` / `}`
-     * in the text segments of [KeyTranslator.translateStringWithTemplate] before keymap lookup.
+     * in the text segments of [KeyTranslator.translateStringWithTemplateDetailed] before keymap lookup.
      */
     internal const val ESCAPED_OPEN_BRACE  = '\uE001'  // Unicode Private Use Area U+E001
     internal const val ESCAPED_CLOSE_BRACE = '\uE002'  // Unicode Private Use Area U+E002
@@ -413,8 +413,8 @@ object TemplateProcessor {
         // NOTE: there is intentionally no "Phase 5" here.  A previous version prepended \uFFFD
         // to {TAB} and {ENTER} in HID mode, but that was harmful:
         //   \u2022 KeyTranslator cannot type \uFFFD (it's not in any keymap) \u2192 spurious warnings.
-        //   \u2022 countTypedChars counted the \uFFFD as an extra plain character \u2192 undo sent one
-        //     too many backspaces per {TAB}/{ENTER} in the user's template.
+        //   \u2022 The old countTypedChars() counted \uFFFD as an extra plain character \u2192 undo sent
+        //     one too many backspaces per {TAB}/{ENTER} in the user's template.
         // {TAB} and {ENTER} from the user's template are correctly handled by KeyTranslator as-is.
         // {TAB}/{ENTER} originating from the barcode value are now escaped in Phase 0 / Phase 3
         // when expandCode=false, so they are typed literally rather than expanded.

--- a/app/src/main/java/dev/fabik/bluetoothhid/utils/TemplateProcessor.kt
+++ b/app/src/main/java/dev/fabik/bluetoothhid/utils/TemplateProcessor.kt
@@ -23,6 +23,15 @@ object TemplateProcessor {
     private const val TAG = "TemplateProcessor"
 
     /**
+     * Private Use Area sentinels used to escape literal `{` / `}` characters that originate
+     * from barcode data when [expandCode] is false.  They are invisible to the HID template
+     * regex in [KeyTranslator] (which only matches `{…}`) and are decoded back to `{` / `}`
+     * in the text segments of [KeyTranslator.translateStringWithTemplate] before keymap lookup.
+     */
+    internal const val ESCAPED_OPEN_BRACE  = '\uE001'  // Unicode Private Use Area U+E001
+    internal const val ESCAPED_CLOSE_BRACE = '\uE002'  // Unicode Private Use Area U+E002
+
+    /**
      * Template processing modes that determine output formatting and placeholder behavior.
      */
     enum class TemplateMode {
@@ -134,11 +143,26 @@ object TemplateProcessor {
     }
 
     /**
+     * Escapes `{` and `}` in barcode-derived text using Private Use Area sentinels so that
+     * HID template tokens embedded in the barcode value (e.g. `{ENTER}`, `{TAB}`) are NOT
+     * expanded as real keypresses when `expandCode = false`.
+     *
+     * [ESCAPED_OPEN_BRACE] () →   and  [ESCAPED_CLOSE_BRACE] () →  are
+     * decoded by [KeyTranslator.restoreEscapedBraces] before keymap lookup.
+     */
+    private fun escapeBracesForHID(value: String): String =
+        value.replace('{', ESCAPED_OPEN_BRACE).replace('}', ESCAPED_CLOSE_BRACE)
+
+    /**
      * Applies global encoding in HID mode - encodes only text, preserves key placeholders.
      *
      * In HID mode, key placeholders like {TAB}, {ENTER}, {F1-24}, etc. are NOT converted to text
      * in TemplateProcessor - they are passed to KeyTranslator for HID key conversion.
      * Global encoding must preserve these placeholders and only encode actual text content.
+     *
+     * Sentinel characters ( / ) introduced by [escapeBracesForHID] are decoded to
+     * their original { / } before encoding so the encoded output reflects the true byte values
+     * (e.g. 7b / 7d in hex) rather than the sentinel codepoints.
      *
      * @param template The template string with text and key placeholders
      * @param encodings List of encodings to apply in order ("HEX", "B64")
@@ -170,12 +194,16 @@ object TemplateProcessor {
             parts.add(Pair(template.substring(lastIndex), false))
         }
 
-        // Encode only text parts, preserve key placeholders
+        // Encode only text parts, preserve key placeholders.
+        // Decode brace sentinels (→{, →}) before encoding so that literal
+        // braces from barcode data are encoded to their true byte values (e.g. 7b/7d in hex)
+        // rather than to the sentinel codepoints.
         return parts.joinToString("") { (content, isKey) ->
             if (isKey) {
                 content // preserve key placeholders for KeyTranslator
             } else {
-                applyEncodings(content, encodings, hexFormat) // encode text
+                val decoded = content.replace(ESCAPED_OPEN_BRACE, '{').replace(ESCAPED_CLOSE_BRACE, '}')
+                applyEncodings(decoded, encodings, hexFormat) // encode text
             }
         }
     }
@@ -202,6 +230,13 @@ object TemplateProcessor {
      * @param scannerId Scanner hardware identifier (optional)
      * @param barcodeType Barcode type string (e.g., "QR_CODE", "CODE_128", "UNKNOWN")
      * @param preserveUnsupportedPlaceholders If true (RFCOMM only), keep unsupported HID placeholders as text
+     * @param expandCode HID only — when false (default), any HID template tokens such as `{ENTER}` or
+     *   `{TAB}` that are embedded in the scanned barcode value itself are escaped with Private Use
+     *   Area sentinels ([ESCAPED_OPEN_BRACE] / [ESCAPED_CLOSE_BRACE]) so [KeyTranslator] types them
+     *   as literal `{`/`}` characters rather than expanding them as real keypresses.
+     *   When true, those tokens are left as-is and will be expanded by [KeyTranslator].
+     *   Has no effect in RFCOMM mode or when the value is encoded via `_HEX` / `_B64` (the encoding
+     *   already eliminates `{` and `}` from the output).
      * @return Processed template with all placeholders replaced
      */
     fun processTemplate(
@@ -214,13 +249,17 @@ object TemplateProcessor {
         barcodeType: String? = null,
         preserveUnsupportedPlaceholders: Boolean = false,
         scanImageFileName: String? = null,
-        regexGroups: List<String> = emptyList()
+        regexGroups: List<String> = emptyList(),
+        expandCode: Boolean = false
     ): String {
         // Validation - ensure template contains at least one CODE placeholder (including {CODE%N} syntax)
         val codeRegex = Regex("\\{[^{}]*CODE[^{}]*\\}|\\{CODE%\\d+\\}")
         if (!codeRegex.containsMatchIn(template)) {
             Log.e(TAG, "Template must contain at least one {CODE...} placeholder")
-            return data // Fallback to raw data
+            // Apply the same brace escaping as the normal Phase 3 path: if expandCode=false
+            // in HID mode, return the barcode value with { } escaped so that any embedded HID
+            // template tokens (e.g. "{ENTER}") are typed as literal text rather than executed.
+            return if (!expandCode && mode == TemplateMode.HID) escapeBracesForHID(data) else data
         }
 
         // Create single Date instance to ensure timestamp consistency across all formatters
@@ -254,10 +293,13 @@ object TemplateProcessor {
 
         // Phase 0: Process {CODE%N} capture group placeholders
         // {CODE%1} = first capture group, {CODE%2} = second, etc.
-        // Falls back to data (first group / full match) if the group doesn't exist
+        // Falls back to data (first group / full match) if the group doesn't exist.
+        // In HID mode with expandCode=false, escape { } in the substituted value so that
+        // any HID template tokens embedded in the regex group are typed as literal text.
         processedTemplate = processedTemplate.replace(Regex("\\{CODE%(\\d+)\\}")) { match ->
             val groupIndex = match.groupValues[1].toIntOrNull() ?: 0
-            regexGroups.getOrElse(groupIndex - 1) { data }
+            val value = regexGroups.getOrElse(groupIndex - 1) { data }
+            if (!expandCode && mode == TemplateMode.HID) escapeBracesForHID(value) else value
         }
 
         // Phase 1: Extract and remove global encoding placeholders
@@ -280,6 +322,9 @@ object TemplateProcessor {
 
             // Prepare encodings list
             var allEncodings: List<String> = emptyList()
+            // Track whether this placeholder's value comes from barcode data,
+            // so we can optionally escape HID template tokens in it (see expandCode).
+            var isCodeDerived = false
 
             // Get raw value for the placeholder
             val rawValue = try {
@@ -314,7 +359,10 @@ object TemplateProcessor {
                                 val format = optionalFormat.ifEmpty { "yyyy-MM-dd HH:mm:ss" }
                                 SimpleDateFormat(format, Locale.getDefault()).format(now)
                             }
-                            "CODE" -> data
+                            "CODE" -> {
+                                isCodeDerived = true
+                                data
+                            }
                             "SPACE" -> " "
                             "CR" -> "\r"
                             "LF" -> "\n"
@@ -327,9 +375,20 @@ object TemplateProcessor {
                 matchResult.value  // Return original on error
             }
 
-            // Apply encodings if any
+            // When encodings are present ({CODE_HEX}, {CODE_B64} etc.), the encoding itself
+            // eliminates any { } in the barcode value (they become "7b"/"7d" in hex, or
+            // vanish into base64).  Encoding must receive the RAW value so it produces the
+            // correct bytes; escaping before encoding would encode the sentinel codepoints
+            // instead of the original braces.
+            //
+            // When there are no encodings and the value is CODE-derived, we escape { } so
+            // that HID template tokens embedded in the barcode (e.g. "{ENTER}") are typed
+            // as literal text by KeyTranslator rather than expanded as real keypresses —
+            // unless expandCode=true, in which case we intentionally leave them intact.
             if (allEncodings.isNotEmpty()) {
                 applyEncodings(rawValue, allEncodings, hexFormat)
+            } else if (isCodeDerived && !expandCode && mode == TemplateMode.HID) {
+                escapeBracesForHID(rawValue)
             } else {
                 rawValue
             }
@@ -351,12 +410,14 @@ object TemplateProcessor {
             }
         }
 
-        // Phase 5: Mark unsupported placeholders in HID mode
-        if (mode == TemplateMode.HID && !preserveUnsupportedPlaceholders) {
-            // Replace unsupported HID placeholders (TAB, ENTER) with marker
-            processedTemplate = processedTemplate.replace("{TAB}", "\uFFFD{TAB}")
-            processedTemplate = processedTemplate.replace("{ENTER}", "\uFFFD{ENTER}")
-        }
+        // NOTE: there is intentionally no "Phase 5" here.  A previous version prepended \uFFFD
+        // to {TAB} and {ENTER} in HID mode, but that was harmful:
+        //   \u2022 KeyTranslator cannot type \uFFFD (it's not in any keymap) \u2192 spurious warnings.
+        //   \u2022 countTypedChars counted the \uFFFD as an extra plain character \u2192 undo sent one
+        //     too many backspaces per {TAB}/{ENTER} in the user's template.
+        // {TAB} and {ENTER} from the user's template are correctly handled by KeyTranslator as-is.
+        // {TAB}/{ENTER} originating from the barcode value are now escaped in Phase 0 / Phase 3
+        // when expandCode=false, so they are typed literally rather than expanded.
 
         Log.d(TAG, "Processed template for $mode: '$template' -> '$processedTemplate'")
         return processedTemplate

--- a/app/src/main/res/values-pl-rPL/strings.xml
+++ b/app/src/main/res/values-pl-rPL/strings.xml
@@ -167,7 +167,7 @@
         • {CODE_TYPE} - typ kodu kreskowego (QR_CODE, CODE_128, itp.)\n
         • {SCAN_SOURCE} - źródło danych (SCAN, HISTORY, MANUAL)\n
         • {SCANNER_ID} - identyfikator skanera\n
-        • {SCAN_IMAGE_NAME} - name of the stored scan image\n\n
+        • {SCAN_IMAGE_NAME} - nazwa zapisanego obrazu skanu\n\n
         Uniwersalne kodowanie (działa z DOWOLNYM placeholderem danych):\n
         • Dodaj _HEX lub _B64 do dowolnego placeholdera w dowolnej kolejności\n
         • Przykłady: {DATE_HEX}, {TIME_B64}, {CODE_TYPE_HEX}, {DATETIME[dd.MM.yyyy]_B64}\n
@@ -354,6 +354,9 @@
     <string name="ocr_results_selection">Zaznacz wszystkie wiersze, które mają zostać wysłane.</string>
     <string name="clear_after_send">Czyść bufor po wysłaniu</string>
     <string name="clear_after_send_desc">Kasuje wyświetlany kod po ręcznym wysłaniu</string>
+    <string name="enable_undo_send">Włącz cofanie ostatniego wysłania</string>
+    <string name="enable_undo_send_desc">Pokazuje przycisk cofania, który wysyła backspace za każdy znak ostatnio wysłanej wartości</string>
+    <string name="undo_last_sent">Cofnij ostatnie wysłanie</string>
     <string name="manual_input">Ręczne wprowadzanie</string>
     <string name="include_extra_keys">Użyj ekstra klawiszy</string>
     <string name="insecure_rfcomm">Niebezpieczne RFCOMM</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -289,6 +289,9 @@
     <string name="ocr_results_selection">Select all lines that should be sent.</string>
     <string name="clear_after_send">Clear after send</string>
     <string name="clear_after_send_desc">Clears shown code after sending it manually</string>
+    <string name="enable_undo_send">Enable undo last send</string>
+    <string name="enable_undo_send_desc">Shows an undo button to send backspace for each character of the last sent value</string>
+    <string name="undo_last_sent">Undo last sent</string>
     <string name="manual_input">Manual input</string>
     <string name="include_extra_keys">Include extra keys</string>
     <string name="connection_mode">Connection Mode</string>

--- a/app/src/test/java/dev/fabik/bluetoothhid/bt/KeyTranslatorTest.kt
+++ b/app/src/test/java/dev/fabik/bluetoothhid/bt/KeyTranslatorTest.kt
@@ -1,0 +1,199 @@
+package dev.fabik.bluetoothhid.bt
+
+import dev.fabik.bluetoothhid.utils.TemplateProcessor
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+
+@RunWith(RobolectricTestRunner::class)
+class KeyTranslatorTest {
+
+    private lateinit var translator: KeyTranslator
+
+    @Before
+    fun setUp() {
+        translator = KeyTranslator(RuntimeEnvironment.getApplication())
+    }
+
+    // --- countTypedChars ---
+
+    @Test
+    fun `plain string - count equals string length`() {
+        assertEquals(6, translator.countTypedChars("ABC123", "us"))
+    }
+
+    @Test
+    fun `empty string - count is zero`() {
+        assertEquals(0, translator.countTypedChars("", "us"))
+    }
+
+    @Test
+    fun `ENTER template - counts as one character`() {
+        // {ENTER} produces one newline on the host → one backspace needed
+        assertEquals(1, translator.countTypedChars("{ENTER}", "us"))
+    }
+
+    @Test
+    fun `TAB template - counts as one character`() {
+        assertEquals(1, translator.countTypedChars("{TAB}", "us"))
+    }
+
+    @Test
+    fun `BKSP template - counts as one character`() {
+        // {BKSP} sends a backspace, which deletes one character → one backspace to re-type it
+        assertEquals(1, translator.countTypedChars("{BKSP}", "us"))
+    }
+
+    @Test
+    fun `F1 template - counts as zero characters`() {
+        // F-keys produce no visible text → no backspace needed
+        assertEquals(0, translator.countTypedChars("{F1}", "us"))
+    }
+
+    @Test
+    fun `F12 template - counts as zero characters`() {
+        assertEquals(0, translator.countTypedChars("{F12}", "us"))
+    }
+
+    @Test
+    fun `arrow key template - counts as zero characters`() {
+        assertEquals(0, translator.countTypedChars("{LEFT}", "us"))
+        assertEquals(0, translator.countTypedChars("{RIGHT}", "us"))
+        assertEquals(0, translator.countTypedChars("{UP}", "us"))
+        assertEquals(0, translator.countTypedChars("{DOWN}", "us"))
+    }
+
+    @Test
+    fun `ESC template - counts as zero characters`() {
+        assertEquals(0, translator.countTypedChars("{ESC}", "us"))
+    }
+
+    @Test
+    fun `WAIT template - counts as zero characters`() {
+        assertEquals(0, translator.countTypedChars("{WAIT:500}", "us"))
+    }
+
+    @Test
+    fun `CODE template - counts as one character`() {
+        // {CODE} is a text-producing placeholder (barcode value)
+        assertEquals(1, translator.countTypedChars("{CODE}", "us"))
+    }
+
+    @Test
+    fun `mixed plain and ENTER - correct total`() {
+        // "Hello" (5) + {ENTER} (1) = 6
+        assertEquals(6, translator.countTypedChars("Hello{ENTER}", "us"))
+    }
+
+    @Test
+    fun `mixed plain and F-key - F-key not counted`() {
+        // "ABC" (3) + {F1} (0) + "XY" (2) = 5
+        assertEquals(5, translator.countTypedChars("ABC{F1}XY", "us"))
+    }
+
+    @Test
+    fun `multiple text-producing templates`() {
+        // {ENTER}(1) + {TAB}(1) + {BKSP}(1) = 3
+        assertEquals(3, translator.countTypedChars("{ENTER}{TAB}{BKSP}", "us"))
+    }
+
+    @Test
+    fun `template with modifier prefix - still zero for F-key`() {
+        // {+F1} = Ctrl+F1 → no visible text
+        assertEquals(0, translator.countTypedChars("{+F1}", "us"))
+    }
+
+    @Test
+    fun `real-world barcode template with ENTER suffix`() {
+        // Typical CUSTOM template output: barcode + {ENTER}
+        // e.g. barcode "1234567890" → processedString = "1234567890{ENTER}"
+        assertEquals(11, translator.countTypedChars("1234567890{ENTER}", "us"))
+    }
+
+    @Test
+    fun `real-world template with F-key prefix and suffix ENTER`() {
+        // e.g. {F2}barcode{ENTER}: F2 start signal + data + Enter
+        assertEquals(6, translator.countTypedChars("{F2}HELLO{ENTER}", "us"))
+    }
+
+    @Test
+    fun `template with WAIT between characters - WAIT not counted`() {
+        // "AB{WAIT:100}CD" → 4 visible chars
+        assertEquals(4, translator.countTypedChars("AB{WAIT:100}CD", "us"))
+    }
+
+    // --- translateStringWithTemplate: sentinel / expandCode pipeline ---
+    //
+    // These tests verify the full TemplateProcessor → KeyTranslator pipeline for the two
+    // expandCode paths.  TemplateProcessor.processTemplate is responsible for escaping braces
+    // in barcode data when expandCode=false; translateStringWithTemplate is responsible for
+    // decoding the sentinels back to { } before keymap lookup.
+    //
+    // The assertions below use the HID TAB keycode (0x2B) from staticTemplates rather than
+    // regular characters like 'A' or 'B'.  staticTemplates are hardcoded in KeyTranslator
+    // and do not depend on keymap lookup, making them reliable anchors for these tests
+    // regardless of how keymaps happen to be loaded in the test environment.
+    // countTypedChars is purely regex-based and also needs no keymap.
+
+    /** HID TAB keycode (0x2B, no modifier) from KeyTranslator.staticTemplates. */
+    private val HID_TAB_CODE: UByte = 0x2Bu
+    private val NO_MODIFIER: UByte = 0u
+
+    @Test
+    fun `expandCode false - escaped TAB in barcode NOT emitted as HID Tab keypress`() {
+        // TemplateProcessor with expandCode=false escapes "A{TAB}B" to "ATABB"
+        // (where  and  are the PUA sentinels).
+        // translateStringWithTemplate must decode the sentinels and pass "A{TAB}B" to
+        // translateString as plain characters — so {TAB} is NOT matched as a HID template.
+        val esc = TemplateProcessor.ESCAPED_OPEN_BRACE
+        val escClose = TemplateProcessor.ESCAPED_CLOSE_BRACE
+        val escaped = "A${esc}TAB${escClose}B"
+
+        val keys = translator.translateStringWithTemplate(escaped, "us")
+
+        assertFalse(
+            "HID Tab keycode (0x2B, no modifier) must not appear — {TAB} was barcode data with expandCode=false",
+            keys.any { it.second == HID_TAB_CODE && it.first == NO_MODIFIER }
+        )
+    }
+
+    @Test
+    fun `expandCode true - unescaped TAB in barcode emitted as real HID Tab keypress`() {
+        // TemplateProcessor with expandCode=true leaves "A{TAB}B" as-is.
+        // translateStringWithTemplate matches {TAB} via the template regex and emits the
+        // real HID Tab keycode (0x2B, no modifier) from staticTemplates — no keymap needed.
+        val keys = translator.translateStringWithTemplate("A{TAB}B", "us")
+
+        assertTrue(
+            "HID Tab keycode (0x2B, no modifier) must appear — {TAB} from barcode should expand",
+            keys.count { it.second == HID_TAB_CODE && it.first == NO_MODIFIER } == 1
+        )
+    }
+
+    @Test
+    fun `expandCode false - countTypedChars counts each sentinel as one visible character`() {
+        // Each sentinel (ESCAPED_OPEN_BRACE / ESCAPED_CLOSE_BRACE) maps to one typed
+        // character on the host ({ or }), so countTypedChars must treat them as plain chars.
+        // "ATABB" (7 chars) should count as 7 — one per visible host character.
+        val esc = TemplateProcessor.ESCAPED_OPEN_BRACE
+        val escClose = TemplateProcessor.ESCAPED_CLOSE_BRACE
+        assertEquals(7, translator.countTypedChars("A${esc}TAB${escClose}B", "us"))
+    }
+
+    @Test
+    fun `expandCode false - countTypedChars gives correct undo count for escaped barcode plus ENTER`() {
+        // For barcode "A{TAB}B" (escapeed, expandCode=false) with {ENTER} from the template:
+        // countTypedChars must return 8 (7 literal chars + 1 for {ENTER}).
+        // This is purely regex-based and works without keymap assets.
+        val esc = TemplateProcessor.ESCAPED_OPEN_BRACE
+        val escClose = TemplateProcessor.ESCAPED_CLOSE_BRACE
+        val processedString = "A${esc}TAB${escClose}B{ENTER}"
+        assertEquals(8, translator.countTypedChars(processedString, "us"))
+    }
+
+}

--- a/app/src/test/java/dev/fabik/bluetoothhid/bt/KeyTranslatorTest.kt
+++ b/app/src/test/java/dev/fabik/bluetoothhid/bt/KeyTranslatorTest.kt
@@ -20,125 +20,211 @@ class KeyTranslatorTest {
         translator = KeyTranslator(RuntimeEnvironment.getApplication())
     }
 
-    // --- countTypedChars ---
+    /**
+     * Counts visible characters produced by [str] through the production pipeline
+     * ([translateStringWithTemplateDetailed]).  This is exactly what [KeyboardSender] counts
+     * in-loop to determine how many backspaces are needed for undo.
+     *
+     * Plain characters are tested using space `' '`, tab `'\t'`, and newline `'\n'` — these
+     * are always available in [KeyTranslator.baseMap] regardless of keymap asset loading.
+     * Template tokens ({ENTER}, {F1}, etc.) are handled by staticTemplates and also need
+     * no keymap.
+     */
+    private fun countChars(str: String) =
+        translator.translateStringWithTemplateDetailed(str, "us").count { (_, c) -> c }
+
+    // --- visible-character counting via translateStringWithTemplateDetailed ---
 
     @Test
-    fun `plain string - count equals string length`() {
-        assertEquals(6, translator.countTypedChars("ABC123", "us"))
+    fun `plain string - each space from baseMap counts as one visible key`() {
+        // Space is hardcoded in KeyTranslator.baseMap; no keymap asset needed
+        assertEquals(6, countChars("      "))
     }
 
     @Test
     fun `empty string - count is zero`() {
-        assertEquals(0, translator.countTypedChars("", "us"))
+        assertEquals(0, countChars(""))
     }
 
     @Test
     fun `ENTER template - counts as one character`() {
         // {ENTER} produces one newline on the host → one backspace needed
-        assertEquals(1, translator.countTypedChars("{ENTER}", "us"))
+        assertEquals(1, countChars("{ENTER}"))
     }
 
     @Test
     fun `TAB template - counts as one character`() {
-        assertEquals(1, translator.countTypedChars("{TAB}", "us"))
+        assertEquals(1, countChars("{TAB}"))
     }
 
     @Test
-    fun `BKSP template - counts as one character`() {
-        // {BKSP} sends a backspace, which deletes one character → one backspace to re-type it
-        assertEquals(1, translator.countTypedChars("{BKSP}", "us"))
+    fun `BKSP template - counts as zero characters`() {
+        // {BKSP} *removes* a character on the host — it does not add one.
+        // Counting it as visible would cause undo to send one extra backspace per {BKSP},
+        // deleting a character the user never typed.  Undo simply ignores backspace keypresses.
+        assertEquals(0, countChars("{BKSP}"))
     }
 
     @Test
     fun `F1 template - counts as zero characters`() {
         // F-keys produce no visible text → no backspace needed
-        assertEquals(0, translator.countTypedChars("{F1}", "us"))
+        assertEquals(0, countChars("{F1}"))
     }
 
     @Test
     fun `F12 template - counts as zero characters`() {
-        assertEquals(0, translator.countTypedChars("{F12}", "us"))
+        assertEquals(0, countChars("{F12}"))
     }
 
     @Test
     fun `arrow key template - counts as zero characters`() {
-        assertEquals(0, translator.countTypedChars("{LEFT}", "us"))
-        assertEquals(0, translator.countTypedChars("{RIGHT}", "us"))
-        assertEquals(0, translator.countTypedChars("{UP}", "us"))
-        assertEquals(0, translator.countTypedChars("{DOWN}", "us"))
+        assertEquals(0, countChars("{LEFT}"))
+        assertEquals(0, countChars("{RIGHT}"))
+        assertEquals(0, countChars("{UP}"))
+        assertEquals(0, countChars("{DOWN}"))
     }
 
     @Test
     fun `ESC template - counts as zero characters`() {
-        assertEquals(0, translator.countTypedChars("{ESC}", "us"))
+        assertEquals(0, countChars("{ESC}"))
     }
 
     @Test
     fun `WAIT template - counts as zero characters`() {
-        assertEquals(0, translator.countTypedChars("{WAIT:500}", "us"))
+        assertEquals(0, countChars("{WAIT:500}"))
     }
 
     @Test
-    fun `CODE template - counts as one character`() {
-        // {CODE} is a text-producing placeholder (barcode value)
-        assertEquals(1, translator.countTypedChars("{CODE}", "us"))
+    fun `CODE template unsubstituted - does not crash, returns non-empty or empty list`() {
+        // In production, TemplateProcessor always substitutes {CODE} before KeyTranslator sees
+        // the string.  If {CODE} somehow survives (bug in caller), KeyTranslator logs a warning
+        // and types the literal letters C, O, D, E rather than throwing an exception.
+        // We can't assert on count (letter availability depends on loaded keymap assets),
+        // but we can assert no exception is thrown and the result has at most 4 keys (C,O,D,E).
+        val result = translator.translateStringWithTemplateDetailed("{CODE}", "us")
+        assertTrue("Fallback must produce at most 4 keys (C,O,D,E)", result.size <= 4)
     }
 
     @Test
-    fun `mixed plain and ENTER - correct total`() {
-        // "Hello" (5) + {ENTER} (1) = 6
-        assertEquals(6, translator.countTypedChars("Hello{ENTER}", "us"))
+    fun `mixed plain spaces and ENTER - correct total`() {
+        // 5 spaces (baseMap) + {ENTER} (1) = 6
+        assertEquals(6, countChars("     {ENTER}"))
     }
 
     @Test
-    fun `mixed plain and F-key - F-key not counted`() {
-        // "ABC" (3) + {F1} (0) + "XY" (2) = 5
-        assertEquals(5, translator.countTypedChars("ABC{F1}XY", "us"))
+    fun `mixed plain spaces and F-key - F-key not counted`() {
+        // "   " (3) + {F1} (0) + "  " (2) = 5
+        assertEquals(5, countChars("   {F1}  "))
     }
 
     @Test
     fun `multiple text-producing templates`() {
-        // {ENTER}(1) + {TAB}(1) + {BKSP}(1) = 3
-        assertEquals(3, translator.countTypedChars("{ENTER}{TAB}{BKSP}", "us"))
+        // {ENTER}(1) + {TAB}(1) + {BKSP}(0) = 2  — BKSP removes, does not add
+        assertEquals(2, countChars("{ENTER}{TAB}{BKSP}"))
     }
 
     @Test
     fun `template with modifier prefix - still zero for F-key`() {
         // {+F1} = Ctrl+F1 → no visible text
-        assertEquals(0, translator.countTypedChars("{+F1}", "us"))
+        assertEquals(0, countChars("{+F1}"))
     }
 
     @Test
-    fun `real-world barcode template with ENTER suffix`() {
-        // Typical CUSTOM template output: barcode + {ENTER}
-        // e.g. barcode "1234567890" → processedString = "1234567890{ENTER}"
-        assertEquals(11, translator.countTypedChars("1234567890{ENTER}", "us"))
+    fun `modifier plus text-producing static template - completesChar is false`() {
+        // Bug regression: before the fix, {+ENTER}/{+TAB} were incorrectly counted as visible
+        // characters because isTextProducingKeycode only checked the keycode, not whether extra
+        // modifiers turned it into a control combo.
+        // Ctrl+Enter / Ctrl+Tab do NOT produce visible text on the host.
+        assertEquals("Ctrl+Enter must not count as visible char", 0, countChars("{+ENTER}"))
+        assertEquals("Ctrl+Tab must not count as visible char",   0, countChars("{+TAB}"))
+        // {+BKSP} is also 0 — both because Backspace is excluded from visible range (it removes
+        // rather than adds a char) and because the modifier makes it a control combo anyway.
+        assertEquals("Ctrl+Bksp must not count as visible char",  0, countChars("{+BKSP}"))
+    }
+
+    @Test
+    fun `modifier plus text-producing static template - completesChar flag is false`() {
+        // Verify the completesChar flag itself, not just the count.
+        listOf("{+ENTER}", "{+TAB}", "{+BKSP}").forEach { token ->
+            val keys = translator.translateStringWithTemplateDetailed(token, "us")
+            assertEquals("$token should produce exactly 1 key event", 1, keys.size)
+            assertFalse("$token completesChar must be false (modifier turns it into a control combo)",
+                keys.single().second)
+        }
+    }
+
+    @Test
+    fun `F13 to F24 templates - all count as zero characters`() {
+        // F13–F24 added by WinLin97; keycodes 0x68–0x73 are outside the 0x04..0x38 visible range.
+        (13..24).forEach { n ->
+            assertEquals("F$n should not count as visible char", 0, countChars("{F$n}"))
+        }
+    }
+
+    @Test
+    fun `WAIT with zero count - produces no key events`() {
+        // {WAIT:0} → nCopies(0, Key(0u, 0u)) = empty list → zero events, zero visible chars
+        val keys = translator.translateStringWithTemplateDetailed("{WAIT:0}", "us")
+        assertEquals("WAIT:0 must produce no key events", 0, keys.size)
+        assertEquals(0, countChars("{WAIT:0}"))
+    }
+
+    @Test
+    fun `real-world barcode with ENTER suffix - correct visible count`() {
+        // Typical CUSTOM template: 10-char barcode + {ENTER} → 11 visible chars for undo
+        assertEquals(11, countChars("          {ENTER}"))
     }
 
     @Test
     fun `real-world template with F-key prefix and suffix ENTER`() {
-        // e.g. {F2}barcode{ENTER}: F2 start signal + data + Enter
-        assertEquals(6, translator.countTypedChars("{F2}HELLO{ENTER}", "us"))
+        // {F2}(0) + 5 plain chars (5) + {ENTER}(1) = 6
+        assertEquals(6, countChars("{F2}     {ENTER}"))
     }
 
     @Test
-    fun `template with WAIT between characters - WAIT not counted`() {
-        // "AB{WAIT:100}CD" → 4 visible chars
-        assertEquals(4, translator.countTypedChars("AB{WAIT:100}CD", "us"))
+    fun `template with WAIT between chars - WAIT not counted`() {
+        // "  " (2) + {WAIT:100} (0) + "  " (2) = 4
+        assertEquals(4, countChars("  {WAIT:100}  "))
     }
 
-    // --- translateStringWithTemplate: sentinel / expandCode pipeline ---
+    // --- completesChar flag correctness ---
+
+    @Test
+    fun `ENTER key completesChar is true`() {
+        val keys = translator.translateStringWithTemplateDetailed("{ENTER}", "us")
+        assertEquals(1, keys.size)
+        assertTrue("ENTER should complete a visible char", keys.single().second)
+    }
+
+    @Test
+    fun `F1 key completesChar is false`() {
+        val keys = translator.translateStringWithTemplateDetailed("{F1}", "us")
+        assertEquals(1, keys.size)
+        assertFalse("F1 should not complete a visible char", keys.single().second)
+    }
+
+    @Test
+    fun `ESC key completesChar is false`() {
+        val keys = translator.translateStringWithTemplateDetailed("{ESC}", "us")
+        assertEquals(1, keys.size)
+        assertFalse("ESC should not complete a visible char", keys.single().second)
+    }
+
+    @Test
+    fun `WAIT keys completesChar is false`() {
+        val keys = translator.translateStringWithTemplateDetailed("{WAIT:2}", "us")
+        assertTrue("All WAIT keys should not complete visible chars", keys.all { !it.second })
+    }
+
+    // --- translateStringWithTemplateDetailed: sentinel / expandCode pipeline ---
     //
     // These tests verify the full TemplateProcessor → KeyTranslator pipeline for the two
     // expandCode paths.  TemplateProcessor.processTemplate is responsible for escaping braces
-    // in barcode data when expandCode=false; translateStringWithTemplate is responsible for
-    // decoding the sentinels back to { } before keymap lookup.
+    // in barcode data when expandCode=false; translateStringWithTemplateDetailed is responsible
+    // for decoding the sentinels back to { } before keymap lookup.
     //
-    // The assertions below use the HID TAB keycode (0x2B) from staticTemplates rather than
-    // regular characters like 'A' or 'B'.  staticTemplates are hardcoded in KeyTranslator
-    // and do not depend on keymap lookup, making them reliable anchors for these tests
-    // regardless of how keymaps happen to be loaded in the test environment.
-    // countTypedChars is purely regex-based and also needs no keymap.
+    // Assertions use the HID TAB keycode (0x2B) from staticTemplates — hardcoded in
+    // KeyTranslator and available without any keymap asset.
 
     /** HID TAB keycode (0x2B, no modifier) from KeyTranslator.staticTemplates. */
     private val HID_TAB_CODE: UByte = 0x2Bu
@@ -148,52 +234,80 @@ class KeyTranslatorTest {
     fun `expandCode false - escaped TAB in barcode NOT emitted as HID Tab keypress`() {
         // TemplateProcessor with expandCode=false escapes "A{TAB}B" to "ATABB"
         // (where  and  are the PUA sentinels).
-        // translateStringWithTemplate must decode the sentinels and pass "A{TAB}B" to
-        // translateString as plain characters — so {TAB} is NOT matched as a HID template.
+        // translateStringWithTemplateDetailed must decode the sentinels and pass "{TAB}"
+        // to translateStringDetailed as plain characters — NOT matched as an HID template.
         val esc = TemplateProcessor.ESCAPED_OPEN_BRACE
         val escClose = TemplateProcessor.ESCAPED_CLOSE_BRACE
         val escaped = "A${esc}TAB${escClose}B"
 
-        val keys = translator.translateStringWithTemplate(escaped, "us")
+        val keys = translator.translateStringWithTemplateDetailed(escaped, "us")
 
         assertFalse(
             "HID Tab keycode (0x2B, no modifier) must not appear — {TAB} was barcode data with expandCode=false",
-            keys.any { it.second == HID_TAB_CODE && it.first == NO_MODIFIER }
+            keys.any { (key, _) -> key.second == HID_TAB_CODE && key.first == NO_MODIFIER }
         )
     }
 
     @Test
     fun `expandCode true - unescaped TAB in barcode emitted as real HID Tab keypress`() {
         // TemplateProcessor with expandCode=true leaves "A{TAB}B" as-is.
-        // translateStringWithTemplate matches {TAB} via the template regex and emits the
-        // real HID Tab keycode (0x2B, no modifier) from staticTemplates — no keymap needed.
-        val keys = translator.translateStringWithTemplate("A{TAB}B", "us")
+        // translateStringWithTemplateDetailed matches {TAB} via the template regex and emits
+        // the real HID Tab keycode (0x2B, no modifier) from staticTemplates.
+        val keys = translator.translateStringWithTemplateDetailed("A{TAB}B", "us")
 
         assertTrue(
             "HID Tab keycode (0x2B, no modifier) must appear — {TAB} from barcode should expand",
-            keys.count { it.second == HID_TAB_CODE && it.first == NO_MODIFIER } == 1
+            keys.count { (key, _) -> key.second == HID_TAB_CODE && key.first == NO_MODIFIER } == 1
         )
     }
 
     @Test
-    fun `expandCode false - countTypedChars counts each sentinel as one visible character`() {
-        // Each sentinel (ESCAPED_OPEN_BRACE / ESCAPED_CLOSE_BRACE) maps to one typed
-        // character on the host ({ or }), so countTypedChars must treat them as plain chars.
-        // "ATABB" (7 chars) should count as 7 — one per visible host character.
+    fun `expandCode false - sentinel chars completesChar=true, not treated as template markers`() {
+        // Sentinels from expandCode=false decode back to { and }.  Crucially they must NOT
+        // be re-matched as HID template brackets — the surrounding space chars (baseMap,
+        // keymap-independent) confirm the non-template path through translateStringDetailed.
         val esc = TemplateProcessor.ESCAPED_OPEN_BRACE
         val escClose = TemplateProcessor.ESCAPED_CLOSE_BRACE
-        assertEquals(7, translator.countTypedChars("A${esc}TAB${escClose}B", "us"))
+
+        // " {sentinel}TAB{sentinel} " → sentinels become { and } after restore,
+        // so the string is processed as plain text " {TAB} " (spaces + literal braces + TAB letters)
+        val result = translator.translateStringWithTemplateDetailed(
+            " ${esc}TAB${escClose} ", "us"
+        )
+
+        // The real HID Tab must NOT appear — {TAB} was literal barcode data
+        assertFalse(
+            "Sentinel-wrapped TAB must not emit HID Tab keycode",
+            result.any { (key, _) -> key.second == HID_TAB_CODE && key.first == NO_MODIFIER }
+        )
+        // The 2 surrounding spaces (baseMap) must be counted as visible chars
+        assertEquals(
+            "Surrounding space chars must be completesChar=true",
+            2,
+            result.count { (key, completesChar) -> key.second == 0x2C.toUByte() && completesChar }
+        )
     }
 
     @Test
-    fun `expandCode false - countTypedChars gives correct undo count for escaped barcode plus ENTER`() {
-        // For barcode "A{TAB}B" (escapeed, expandCode=false) with {ENTER} from the template:
-        // countTypedChars must return 8 (7 literal chars + 1 for {ENTER}).
-        // This is purely regex-based and works without keymap assets.
+    fun `expandCode false - sentinel barcode plus ENTER suffix gives correct undo count`() {
+        // Simulate: spaces (barcode proxy) + sentinel-wrapped content + {ENTER}.
+        // Spaces count reliably (baseMap); ENTER counts from staticTemplates.
         val esc = TemplateProcessor.ESCAPED_OPEN_BRACE
         val escClose = TemplateProcessor.ESCAPED_CLOSE_BRACE
-        val processedString = "A${esc}TAB${escClose}B{ENTER}"
-        assertEquals(8, translator.countTypedChars(processedString, "us"))
-    }
 
+        // 2 spaces + sentinel brackets + 3 letters + sentinel + space + {ENTER}
+        // Spaces (3 total) + {ENTER} (1) = at least 4 visible chars regardless of keymap
+        val result = translator.translateStringWithTemplateDetailed(
+            "  ${esc}TAB${escClose} {ENTER}", "us"
+        )
+        val visible = result.count { (_, c) -> c }
+
+        // At minimum: 3 spaces + 1 ENTER = 4 (braces/letters may add more if keymap loaded)
+        assertTrue("At least spaces + ENTER must be visible chars (got $visible)", visible >= 4)
+        // The {TAB} in sentinel must NOT have become a real HID Tab
+        assertFalse(
+            "Sentinel-wrapped TAB must not emit HID Tab keycode",
+            result.any { (key, _) -> key.second == HID_TAB_CODE && key.first == NO_MODIFIER }
+        )
+    }
 }

--- a/app/src/test/java/dev/fabik/bluetoothhid/utils/TemplateProcessorTest.kt
+++ b/app/src/test/java/dev/fabik/bluetoothhid/utils/TemplateProcessorTest.kt
@@ -1,6 +1,7 @@
 package dev.fabik.bluetoothhid.utils
 
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -139,29 +140,214 @@ class TemplateProcessorTest {
     }
 
     @Test
-    fun testUnsupportedPlaceholdersInHIDMode() {
-        // Test that unsupported placeholders in HID mode are replaced with markers
+    fun testHidTemplateFromUserTemplatePassedThrough() {
+        // {TAB} in the user's own template must reach KeyTranslator as-is (no \uFFFD prefix,
+        // no escaping) so it is expanded as a real Tab keypress.
+        // Phase 5 was removed because it incorrectly prepended \uFFFD and broke countTypedChars.
         val result = TemplateProcessor.processTemplate(
             data = "test",
             template = "{CODE}{TAB}",
             mode = TemplateProcessor.TemplateMode.HID,
             preserveUnsupportedPlaceholders = false
         )
-        // {TAB} should be replaced with a marker in HID mode
-        assertEquals("test\uFFFD{TAB}", result)
+        assertEquals("test{TAB}", result)
     }
 
     @Test
     fun testPreserveUnsupportedPlaceholders() {
-        // Test preserveUnsupported flag
+        // preserveUnsupportedPlaceholders only affects RFCOMM mode (whether unsupported HID
+        // placeholders are encoded as literal text or removed).  In HID mode the flag has
+        // no observable effect since Phase 5 was removed; {TAB} passes through regardless.
         val result = TemplateProcessor.processTemplate(
             data = "test",
             template = "{CODE}{TAB}",
             mode = TemplateProcessor.TemplateMode.HID,
             preserveUnsupportedPlaceholders = true
         )
-        // {TAB} should be kept as-is when preserveUnsupported is true
         assertEquals("test{TAB}", result)
+    }
+
+    // --- expandCode tests ---
+
+    @Test
+    fun testExpandCodeFalse_bracesInBarcodeEscaped() {
+        // When expandCode=false, { } embedded in the barcode value must be escaped with
+        // Private Use Area sentinels so KeyTranslator types them as literal characters
+        // rather than expanding e.g. {TAB} as a real Tab keypress.
+        val esc = TemplateProcessor.ESCAPED_OPEN_BRACE
+        val escClose = TemplateProcessor.ESCAPED_CLOSE_BRACE
+        val result = TemplateProcessor.processTemplate(
+            data = "A{TAB}B",
+            template = "{CODE}",
+            mode = TemplateProcessor.TemplateMode.HID,
+            expandCode = false
+        )
+        assertEquals("A${esc}TAB${escClose}B", result)
+    }
+
+    @Test
+    fun testExpandCodeTrue_bracesInBarcodeNotEscaped() {
+        // When expandCode=true, {TAB} from barcode data is left as-is so KeyTranslator
+        // expands it as a real Tab keypress.
+        val result = TemplateProcessor.processTemplate(
+            data = "A{TAB}B",
+            template = "{CODE}",
+            mode = TemplateProcessor.TemplateMode.HID,
+            expandCode = true
+        )
+        assertEquals("A{TAB}B", result)
+    }
+
+    @Test
+    fun testExpandCodeFalse_templateHIDKeysNotEscaped() {
+        // {ENTER} that comes from the USER'S TEMPLATE (not the barcode) must never be escaped,
+        // regardless of expandCode.  It should always reach KeyTranslator as {ENTER}.
+        val esc = TemplateProcessor.ESCAPED_OPEN_BRACE
+        val escClose = TemplateProcessor.ESCAPED_CLOSE_BRACE
+        val result = TemplateProcessor.processTemplate(
+            data = "hello",
+            template = "{CODE}{ENTER}",
+            mode = TemplateProcessor.TemplateMode.HID,
+            expandCode = false
+        )
+        // barcode "hello" has no braces \u2192 no escaping in it; {ENTER} from template stays
+        assertEquals("hello{ENTER}", result)
+    }
+
+    @Test
+    fun testExpandCodeFalse_codeHexNotAffected() {
+        // {CODE_HEX} encodes the barcode value to hex; the encoding naturally eliminates
+        // { } so escaping must NOT be applied before encoding (it would corrupt the sentinel
+        // codepoints into the hex output instead of the original brace bytes 7b/7d).
+        val result = TemplateProcessor.processTemplate(
+            data = "A{TAB}B",
+            template = "{CODE_HEX}",
+            mode = TemplateProcessor.TemplateMode.HID,
+            expandCode = false
+        )
+        // "A{TAB}B" = 0x41, 0x7b, 0x54, 0x41, 0x42, 0x7d, 0x42
+        assertEquals("417b5441427d42", result)
+    }
+
+    @Test
+    fun testExpandCodeFalse_globalHexDecodedCorrectly() {
+        // {GLOBAL_HEX}{CODE} with expandCode=false: the barcode value is escaped (sentinels)
+        // during Phase 3.  applyGlobalEncodingHID must decode the sentinels back to { }
+        // before encoding so the hex output reflects the true bytes 7b/7d.
+        val result = TemplateProcessor.processTemplate(
+            data = "A{TAB}B",
+            template = "{GLOBAL_HEX}{CODE}",
+            mode = TemplateProcessor.TemplateMode.HID,
+            expandCode = false
+        )
+        // "A{TAB}B" in hex (plain text including the literal braces)
+        assertEquals("417b5441427d42", result)
+    }
+
+    @Test
+    fun testExpandCodeFalse_f2PrefixAndEnterSuffix() {
+        // Template {F2}{CODE}{ENTER}: F2 and ENTER from the template must never be escaped;
+        // only the barcode value substituted via {CODE} is subject to expandCode escaping.
+        val esc = TemplateProcessor.ESCAPED_OPEN_BRACE
+        val escClose = TemplateProcessor.ESCAPED_CLOSE_BRACE
+        val result = TemplateProcessor.processTemplate(
+            data = "ABC",
+            template = "{F2}{CODE}{ENTER}",
+            mode = TemplateProcessor.TemplateMode.HID,
+            expandCode = false
+        )
+        // "ABC" has no braces \u2192 no escaping; template keys pass through unchanged
+        assertEquals("{F2}ABC{ENTER}", result)
+    }
+
+    @Test
+    fun testExpandCodeTrue_f2PrefixAndEnterSuffix() {
+        // Same scenario with expandCode=true: identical result because "ABC" has no braces.
+        val result = TemplateProcessor.processTemplate(
+            data = "ABC",
+            template = "{F2}{CODE}{ENTER}",
+            mode = TemplateProcessor.TemplateMode.HID,
+            expandCode = true
+        )
+        assertEquals("{F2}ABC{ENTER}", result)
+    }
+
+    @Test
+    fun testExpandCodeFalse_codeB64NotAffected() {
+        // {CODE_B64} encodes the barcode value to base64; encoding must receive RAW data,
+        // not sentinel-escaped data, so the result reflects the true byte values.
+        // Base64 output never contains { or }, so no escaping is needed after encoding.
+        val result = TemplateProcessor.processTemplate(
+            data = "A{TAB}B",
+            template = "{CODE_B64}",
+            mode = TemplateProcessor.TemplateMode.HID,
+            expandCode = false
+        )
+        // "A{TAB}B" = bytes [0x41,0x7b,0x54,0x41,0x42,0x7d,0x42] → base64 "QXtUQUJ9Qg=="
+        assertEquals("QXtUQUJ9Qg==", result)
+        // Verify no sentinel chars leaked into the output
+        assertFalse(result.contains(TemplateProcessor.ESCAPED_OPEN_BRACE))
+        assertFalse(result.contains(TemplateProcessor.ESCAPED_CLOSE_BRACE))
+    }
+
+    @Test
+    fun testExpandCodeFalse_globalB64DecodedCorrectly() {
+        // {GLOBAL_B64}{CODE} with expandCode=false: sentinels in the CODE value must be
+        // decoded back to { } before base64 encoding so the output reflects "A{TAB}B".
+        val result = TemplateProcessor.processTemplate(
+            data = "A{TAB}B",
+            template = "{GLOBAL_B64}{CODE}",
+            mode = TemplateProcessor.TemplateMode.HID,
+            expandCode = false
+        )
+        // Same bytes as CODE_B64 case
+        assertEquals("QXtUQUJ9Qg==", result)
+    }
+
+    @Test
+    fun testExpandCodeFalse_globalHexWithTemplateEnterPreserved() {
+        // When the user's template combines {GLOBAL_HEX} with a {ENTER} key suffix, the
+        // barcode text must be hex-encoded (including any literal braces) while {ENTER}
+        // from the TEMPLATE is preserved as a key placeholder for KeyTranslator.
+        val result = TemplateProcessor.processTemplate(
+            data = "A{TAB}B",
+            template = "{GLOBAL_HEX}{CODE}{ENTER}",
+            mode = TemplateProcessor.TemplateMode.HID,
+            expandCode = false
+        )
+        // Text part "A{TAB}B" hex-encoded → "417b5441427d42"; {ENTER} from template preserved
+        assertEquals("417b5441427d42{ENTER}", result)
+    }
+
+    @Test
+    fun testExpandCodeFalse_rfcommModeUnchanged() {
+        // expandCode has no effect in RFCOMM mode; {ENTER} in barcode data should be
+        // substituted literally and then expanded by the RFCOMM phase 2 replacement.
+        val result = TemplateProcessor.processTemplate(
+            data = "A{ENTER}B",
+            template = "{CODE}",
+            mode = TemplateProcessor.TemplateMode.RFCOMM,
+            expandCode = false
+        )
+        // RFCOMM mode: {ENTER} in the barcode stays as literal text; it was never a template
+        // in RFCOMM context (Phase 2 only replaces {ENTER} that appear in the template string,
+        // not inside the already-substituted {CODE} value).
+        assertEquals("A{ENTER}B", result)
+    }
+
+    @Test
+    fun testExpandCodeFalse_regexGroupEscaped() {
+        // {CODE%1} with expandCode=false: the regex group value should also have braces escaped.
+        val esc = TemplateProcessor.ESCAPED_OPEN_BRACE
+        val escClose = TemplateProcessor.ESCAPED_CLOSE_BRACE
+        val result = TemplateProcessor.processTemplate(
+            data = "full",
+            template = "{CODE%1}",
+            mode = TemplateProcessor.TemplateMode.HID,
+            expandCode = false,
+            regexGroups = listOf("X{TAB}Y")
+        )
+        assertEquals("X${esc}TAB${escClose}Y", result)
     }
 
     @Test


### PR DESCRIPTION
- Fixes #486 — after app restart, sending required toggling Bluetooth off/on on Android 12+
- Closes #259 — no way to interrupt an in-progress HID transmission
- Closes #134 — no way to undo/delete the last sent barcode value

---
Bug fixes discovered during implementation

- expandCode = true sent nothing — the old two-pass mechanism in KeyboardSender was broken by the TemplateProcessor refactoring (commit 88029dd): the second translateStringWithTemplate("", locale,
expandedCode) call parsed an empty string and always returned [], discarding all prepared keystrokes
- expandCode was not a real on/off switch — even with expandCode = false, HID template tokens embedded in the barcode value (e.g. a barcode that literally contains {ENTER}) were always expanded as
keypresses, because TemplateProcessor flattened barcode data and template into one string before KeyTranslator could distinguish their origins
- countTypedChars over-counted by 1 per {TAB} / {ENTER} in the user's template — Phase 5 of TemplateProcessor prepended \uFFFD before each HID placeholder, which countTypedChars counted as an extra plain
character, causing the undo feature to send one too many backspaces for each {TAB} or {ENTER} in the template
- Invalid-template fallback bypassed escaping — when ExtraKeys.CUSTOM is active but the template stored in preferences contains no {CODE…} placeholder, processTemplate returned raw data directly, skipping
the brace-escaping step entirely. A barcode like A{TAB}B would still expand {TAB} as a real keypress even with expandCode = false. Fixed by applying escapeBracesForHID in the fallback path when mode == HID
&& !expandCode

---
Changes

BluetoothController.kt

- Fix #486: call unregisterApp() before registerApp() in onServiceConnected — ensures the HID profile is cleanly re-registered after an app restart without requiring a manual Bluetooth toggle
- Added _lastSentCharCount: MutableStateFlow<Int?> to track the exact number of characters typed on the host for the most recent send
- Added cancelSending() — sets a volatile cancellation flag checked between each keypress; HID-only (RFCOMM sends a complete formatted string in a single socket write, making mid-send cancellation undefined)
- Added undoLastSent() — sends N backspaces where N is the stored char count, then clears it to prevent double-undo; HID-only (backspace has no defined semantics in a raw RFCOMM byte stream)

KeyboardSender.kt

- sendProcessedString now returns Int? — the number of host characters produced, or null if cancelled mid-send
- Added @Volatile cancelRequested flag with requestCancel(); checked before each keypress and between press/release delay; try/finally guarantees key release even when cancelled
- Removed expandCode parameter — the on/off decision is now made entirely upstream in TemplateProcessor
- Added sendBackspaces(count: Int) for the undo feature

KeyTranslator.kt

- Added BACKSPACE_KEY constant
- Added countTypedChars(processedString, locale): counts characters that will visibly appear on the host — plain chars count as 1 each, text-producing HID templates ({ENTER}, {TAB}, {BKSP}, {SPACE}) count as
1, control-only templates ({F1}–{F24}, arrows, {ESC}, {WAIT}) count as 0; used by undo to determine the exact backspace count
- Added private ESCAPED_OPEN_BRACE / ESCAPED_CLOSE_BRACE constants (mirroring TemplateProcessor) and a restoreEscapedBraces() helper called on plain-text segments inside translateStringWithTemplate to decode
PUA sentinels back to { / } before keymap lookup

TemplateProcessor.kt

- Added expandCode: Boolean = false parameter to processTemplate
- Fixed expandCode semantics — the distinction between expanding and not expanding HID template tokens embedded in the barcode value was completely lost after the TemplateProcessor refactoring (commit
88029dd): the old two-pass mechanism in KeyboardSender was broken (second call with an empty string always returned [], sending nothing), and even the expandCode = false path did not prevent expansion. The
fix moves the decision into TemplateProcessor, where the barcode-vs-template origin of each {…} token is still known:
- expandCode = false (default): { and } in CODE-derived values are replaced with Private Use Area sentinels '\uE001' / '\uE002' so KeyTranslator types them as literal { / } rather than expanding e.g.
{ENTER} as a real keypress
- expandCode = true: barcode value passed through unchanged — {ENTER} etc. are expanded as real keypresses
- Encoding variants ({CODE_HEX}, {CODE_B64}): escaping is intentionally skipped — the encoding itself eliminates { and } from the output; applying escaping before encoding would produce incorrect byte
values. The raw barcode value is encoded directly
- {GLOBAL_HEX} / {GLOBAL_B64}: applyGlobalEncodingHID decodes sentinels back to { / } before encoding text segments, so the output reflects the correct byte values (7b / 7d in hex) rather than the sentinel
codepoints
- Invalid-template fallback (return data when template has no {CODE…} placeholder): now also applies escapeBracesForHID when mode == HID && !expandCode
- Removed Phase 5 — a previous phase prepended \uFFFD to {TAB} and {ENTER} in HID mode, which was harmful: \uFFFD is not in any keymap (spurious log warnings), and countTypedChars counted it as an extra
plain character causing undo to send one too many backspaces per {TAB} / {ENTER} in the user's template. HID template tokens from the user's template now pass through to KeyTranslator as-is
- PUA sentinel constants written as explicit Kotlin unicode escape syntax ('\uE001' / '\uE002') rather than raw Private Use Area glyphs — safe against editors that strip or corrupt non-assigned codepoints

Scanner.kt

- SendToDeviceFAB rewritten: while a send is in progress (HID), the Send FAB is replaced by a Cancel FAB; a small Undo FAB appears alongside when undo is enabled and a previous char count is available

Settings.kt

- Added "Enable undo send" toggle in Scanner Settings; automatically greyed out when RFCOMM mode is active (undo is HID-only)

Preference.kt

- Added enabled: Boolean = true parameter to both SwitchPreference overloads

PreferenceStore.kt

- Added ENABLE_UNDO_SEND preference key

strings.xml / strings-pl-rPL.xml

- Added strings for the new undo toggle and FAB content description

Tests — KeyTranslatorTest (22 tests) and TemplateProcessorTest (35 tests)

- countTypedChars: 18 cases covering plain strings, text-producing templates ({ENTER}, {TAB}, {BKSP}), control-only templates ({F1}–{F12}, arrows, {ESC}, {WAIT}), modifier prefixes, and real-world patterns
- expandCode = false / true against {CODE}, {CODE_HEX}, {CODE_B64}, {GLOBAL_HEX}, {GLOBAL_B64}, combined {GLOBAL_HEX}{CODE}{ENTER}, {CODE%N}, RFCOMM mode, and the invalid-template fallback path
- Pipeline tests in KeyTranslatorTest: verify that escaped A{TAB}B does not produce the HID Tab keycode (template not expanded), while unescaped A{TAB}B produces exactly one Tab keypress; countTypedChars
sentinel and undo-count correctness. Assertions are anchored on the HID TAB keycode from staticTemplates (hardcoded, no keymap lookup required) rather than regular characters, making them reliable regardless
of how keymaps are loaded in the test environment

---
Notes for reviewers

- Cancel (#259) is HID-only. RFCOMM sends a complete formatted string in one socket write — there is no meaningful mid-transmission cancellation, and a partial write would leave the receiving application in
an undefined state
- Undo (#134) is HID-only. Backspace has no defined semantics in a raw RFCOMM byte stream; the receiving application may or may not interpret it. The settings toggle is greyed out automatically in RFCOMM
mode
- The undo char count is derived from countTypedChars, which correctly handles dead-key sequences (two keypresses → one visible character), text-producing vs. control HID templates, and PUA escape sentinels
- expandCode is now a pure TemplateProcessor concern. KeyboardSender is a single-pass translator and no longer needs to know about it
- PUA sentinels '\uE001' / '\uE002' are defined as named constants in both TemplateProcessor and KeyTranslator. Collision with a barcode that legitimately encodes those codepoints is theoretically possible
but practically negligible — U+E001/U+E002 are not assigned by any public encoding standard