### PR TITLE
Add preference profiles, multiple scan areas, and multi-code picker

### DIFF
--- a/app/src/main/java/dev/fabik/bluetoothhid/MainActivity.kt
+++ b/app/src/main/java/dev/fabik/bluetoothhid/MainActivity.kt
@@ -12,8 +12,10 @@ import androidx.compose.material3.Surface
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.Modifier
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import dev.fabik.bluetoothhid.bt.BluetoothController
 import dev.fabik.bluetoothhid.bt.rememberBluetoothControllerService
 import dev.fabik.bluetoothhid.ui.NavGraph
@@ -21,9 +23,12 @@ import dev.fabik.bluetoothhid.ui.RequiresBluetoothPermission
 import dev.fabik.bluetoothhid.ui.theme.BluetoothHIDTheme
 import dev.fabik.bluetoothhid.ui.theme.configureWindow
 import dev.fabik.bluetoothhid.utils.JsEngineService
+import dev.fabik.bluetoothhid.utils.LocalDataStore
 import dev.fabik.bluetoothhid.utils.PreferenceStore
+import dev.fabik.bluetoothhid.utils.ProfileManager
 import dev.fabik.bluetoothhid.utils.getPreferenceState
 import dev.fabik.bluetoothhid.utils.rememberJsEngineService
+import kotlinx.coroutines.runBlocking
 
 val LocalController = staticCompositionLocalOf<BluetoothController?> {
     null
@@ -43,33 +48,42 @@ class MainActivity : ComponentActivity() {
         // Configure window for high refresh rate and transparency
         configureWindow(window)
 
-        setContent {
-            BluetoothHIDTheme(window = window) {
-                Surface(Modifier.fillMaxSize()) {
-                    val allowScreenRotation by getPreferenceState(PreferenceStore.ALLOW_SCREEN_ROTATION)
+        // Load saved active profile before first composition to avoid a flash of wrong settings
+        runBlocking { ProfileManager.initialize(applicationContext) }
 
-                    allowScreenRotation?.let {
-                        LaunchedEffect(allowScreenRotation) {
-                            requestedOrientation = if (it) {
-                                ActivityInfo.SCREEN_ORIENTATION_FULL_SENSOR
-                            } else {
-                                ActivityInfo.SCREEN_ORIENTATION_NOSENSOR
+        setContent {
+            // Observe active DataStore so all composables recompose on profile switch
+            val activeDataStore by remember { ProfileManager.activeStoreFlow(applicationContext) }
+                .collectAsStateWithLifecycle(initialValue = ProfileManager.currentStore(applicationContext))
+
+            CompositionLocalProvider(LocalDataStore provides activeDataStore) {
+                BluetoothHIDTheme(window = window) {
+                    Surface(Modifier.fillMaxSize()) {
+                        val allowScreenRotation by getPreferenceState(PreferenceStore.ALLOW_SCREEN_ROTATION)
+
+                        allowScreenRotation?.let {
+                            LaunchedEffect(allowScreenRotation) {
+                                requestedOrientation = if (it) {
+                                    ActivityInfo.SCREEN_ORIENTATION_FULL_SENSOR
+                                } else {
+                                    ActivityInfo.SCREEN_ORIENTATION_NOSENSOR
+                                }
                             }
                         }
-                    }
 
-                    RequiresBluetoothPermission {
-                        val bluetoothService = rememberBluetoothControllerService(this)
-                        val jsEngineService = rememberJsEngineService(this)
+                        RequiresBluetoothPermission {
+                            val bluetoothService = rememberBluetoothControllerService(this)
+                            val jsEngineService = rememberJsEngineService(this)
 
-                        CompositionLocalProvider(
-                            LocalController provides bluetoothService?.getController(),
-                            LocalJsEngineService provides jsEngineService
-                        ) {
-                            NavGraph()
+                            CompositionLocalProvider(
+                                LocalController provides bluetoothService?.getController(),
+                                LocalJsEngineService provides jsEngineService
+                            ) {
+                                NavGraph()
+                            }
+
+                            PersistHistory()
                         }
-
-                        PersistHistory()
                     }
                 }
             }

--- a/app/src/main/java/dev/fabik/bluetoothhid/Scanner.kt
+++ b/app/src/main/java/dev/fabik/bluetoothhid/Scanner.kt
@@ -51,6 +51,7 @@ import androidx.compose.material.icons.automirrored.filled.Undo
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.FlashOff
 import androidx.compose.material.icons.filled.FlashOn
+import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.History
 import androidx.compose.material.icons.filled.Keyboard
 import androidx.compose.material.icons.rounded.Warning
@@ -64,6 +65,7 @@ import androidx.compose.material3.rememberSwipeToDismissBoxState
 import androidx.compose.material3.ExtendedFloatingActionButton
 import androidx.compose.material3.FabPosition
 import androidx.compose.material3.SmallFloatingActionButton
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -129,6 +131,9 @@ import dev.fabik.bluetoothhid.ui.model.CameraViewModel.Barcode
 import dev.fabik.bluetoothhid.ui.rememberDialogState
 import dev.fabik.bluetoothhid.ui.tooltip
 import dev.fabik.bluetoothhid.utils.ConnectionMode
+import dev.fabik.bluetoothhid.utils.OverlayType
+import dev.fabik.bluetoothhid.utils.ScanAreaData
+import dev.fabik.bluetoothhid.utils.setPreference
 import dev.fabik.bluetoothhid.utils.DeviceInfo
 import dev.fabik.bluetoothhid.utils.PreferenceStore
 import dev.fabik.bluetoothhid.utils.VolumeKeyAction
@@ -231,8 +236,13 @@ fun Scanner(
     val fullScreen by context.getPreferenceStateBlocking(PreferenceStore.SCANNER_FULL_SCREEN)
     AdaptSystemBarsColor(fullScreen)
 
+    val restrictArea by context.getPreferenceStateBlocking(PreferenceStore.RESTRICT_AREA)
+    val overlayTypeOrdinal by context.getPreferenceStateBlocking(PreferenceStore.OVERLAY_TYPE)
+    val overlayType = OverlayType.fromIndex(overlayTypeOrdinal)
+
     val keyboardDialog = rememberDialogState()
     val cameraVM = viewModel<CameraViewModel>()
+    val scope = rememberCoroutineScope()
 
     // Show a Snackbar when JavaScript evaluation fails
     LaunchedEffect(cameraVM) {
@@ -246,7 +256,18 @@ fun Scanner(
 
     Scaffold(
         topBar = {
-            ScannerAppBar(cameraControl, cameraInfo, currentDevice, fullScreen, keyboardDialog)
+            val onAddArea: (() -> Unit)? = if (restrictArea && overlayType == OverlayType.CUSTOM) {
+                {
+                    cameraVM.areas.add(ScanAreaData(0f, 0f, 100f, 100f))
+                    scope.launch {
+                        context.setPreference(
+                            PreferenceStore.SCAN_AREAS,
+                            ScanAreaData.toJsonArray(cameraVM.areas)
+                        )
+                    }
+                }
+            } else null
+            ScannerAppBar(cameraControl, cameraInfo, currentDevice, fullScreen, keyboardDialog, onAddArea)
         },
         floatingActionButtonPosition = FabPosition.Center,
         floatingActionButton = {
@@ -728,7 +749,8 @@ private fun ScannerAppBar(
     info: CameraInfo?,
     currentDevice: BluetoothDevice?,
     transparent: Boolean,
-    keyboardDialog: DialogState
+    keyboardDialog: DialogState,
+    onAddArea: (() -> Unit)?
 ) {
     val navigation = LocalNavigation.current
 
@@ -800,7 +822,18 @@ private fun ScannerAppBar(
 //            IconButton(onDisconnect, Modifier.tooltip(stringResource(R.string.disconnect))) {
 //                Icon(Icons.Default.BluetoothDisabled, "Disconnect")
 //            }
-            Dropdown(transparent)
+            Dropdown(transparent) { hideMenu ->
+                if (onAddArea != null) {
+                    DropdownMenuItem(
+                        text = { Text(stringResource(R.string.add_scan_area)) },
+                        leadingIcon = { Icon(Icons.Default.Add, null) },
+                        onClick = {
+                            onAddArea()
+                            hideMenu()
+                        }
+                    )
+                }
+            }
         },
         colors = if (transparent) {
             TopAppBarDefaults.topAppBarColors(

--- a/app/src/main/java/dev/fabik/bluetoothhid/Scanner.kt
+++ b/app/src/main/java/dev/fabik/bluetoothhid/Scanner.kt
@@ -2,6 +2,7 @@ package dev.fabik.bluetoothhid
 
 import android.annotation.SuppressLint
 import android.bluetooth.BluetoothDevice
+import android.content.ClipData
 import android.content.Context
 import android.media.AudioManager
 import android.media.ToneGenerator
@@ -20,8 +21,7 @@ import androidx.camera.core.ImageCapture
 import androidx.camera.core.TorchState
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.background
-import androidx.compose.foundation.lazy.LazyRow
-import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxScope
@@ -41,41 +41,42 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.windowInsetsBottomHeight
 import androidx.compose.foundation.layout.windowInsetsTopHeight
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.selection.toggleable
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.text.input.rememberTextFieldState
 import androidx.compose.foundation.text.input.selectAll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.Send
 import androidx.compose.material.icons.automirrored.filled.Undo
+import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.FlashOff
 import androidx.compose.material.icons.filled.FlashOn
-import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.History
 import androidx.compose.material.icons.filled.Keyboard
 import androidx.compose.material.icons.rounded.Warning
 import androidx.compose.material3.Checkbox
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ElevatedCard
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.SuggestionChip
-import androidx.compose.material3.SwipeToDismissBox
-import androidx.compose.material3.SwipeToDismissBoxValue
-import androidx.compose.material3.rememberSwipeToDismissBoxState
 import androidx.compose.material3.ExtendedFloatingActionButton
 import androidx.compose.material3.FabPosition
-import androidx.compose.material3.SmallFloatingActionButton
-import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SmallFloatingActionButton
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.SuggestionChip
+import androidx.compose.material3.SwipeToDismissBox
+import androidx.compose.material3.SwipeToDismissBoxValue
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.material3.rememberSwipeToDismissBoxState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
@@ -97,7 +98,6 @@ import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shadow
 import androidx.compose.ui.graphics.luminance
-import android.content.ClipData
 import androidx.compose.ui.platform.ClipEntry
 import androidx.compose.ui.platform.LocalClipboard
 import androidx.compose.ui.platform.LocalContext
@@ -131,15 +131,15 @@ import dev.fabik.bluetoothhid.ui.model.CameraViewModel.Barcode
 import dev.fabik.bluetoothhid.ui.rememberDialogState
 import dev.fabik.bluetoothhid.ui.tooltip
 import dev.fabik.bluetoothhid.utils.ConnectionMode
-import dev.fabik.bluetoothhid.utils.OverlayType
-import dev.fabik.bluetoothhid.utils.ScanAreaData
-import dev.fabik.bluetoothhid.utils.setPreference
 import dev.fabik.bluetoothhid.utils.DeviceInfo
+import dev.fabik.bluetoothhid.utils.OverlayType
 import dev.fabik.bluetoothhid.utils.PreferenceStore
+import dev.fabik.bluetoothhid.utils.ScanAreaData
 import dev.fabik.bluetoothhid.utils.VolumeKeyAction
 import dev.fabik.bluetoothhid.utils.getPreferenceState
 import dev.fabik.bluetoothhid.utils.getPreferenceStateBlocking
 import dev.fabik.bluetoothhid.utils.getPreferenceStateDefault
+import dev.fabik.bluetoothhid.utils.setPreference
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlin.math.abs
@@ -258,11 +258,11 @@ fun Scanner(
         topBar = {
             val onAddArea: (() -> Unit)? = if (restrictArea && overlayType == OverlayType.CUSTOM) {
                 {
-                    cameraVM.areas.add(ScanAreaData(0f, 0f, 100f, 100f))
+                    cameraVM.addScanAreas(ScanAreaData(0f, 0f, 100f, 100f))
                     scope.launch {
                         context.setPreference(
                             PreferenceStore.SCAN_AREAS,
-                            ScanAreaData.toJsonArray(cameraVM.areas)
+                            ScanAreaData.toJsonArray(cameraVM.areas.value)
                         )
                     }
                 }

--- a/app/src/main/java/dev/fabik/bluetoothhid/Scanner.kt
+++ b/app/src/main/java/dev/fabik/bluetoothhid/Scanner.kt
@@ -20,6 +20,8 @@ import androidx.camera.core.ImageCapture
 import androidx.camera.core.TorchState
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.background
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxScope
@@ -55,6 +57,10 @@ import androidx.compose.material.icons.rounded.Warning
 import androidx.compose.material3.Checkbox
 import androidx.compose.material3.ElevatedCard
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.SuggestionChip
+import androidx.compose.material3.SwipeToDismissBox
+import androidx.compose.material3.SwipeToDismissBoxValue
+import androidx.compose.material3.rememberSwipeToDismissBoxState
 import androidx.compose.material3.ExtendedFloatingActionButton
 import androidx.compose.material3.FabPosition
 import androidx.compose.material3.SmallFloatingActionButton
@@ -119,6 +125,7 @@ import dev.fabik.bluetoothhid.ui.RequiresCameraPermission
 import dev.fabik.bluetoothhid.ui.Routes
 import dev.fabik.bluetoothhid.ui.model.BarcodeResult
 import dev.fabik.bluetoothhid.ui.model.CameraViewModel
+import dev.fabik.bluetoothhid.ui.model.CameraViewModel.Barcode
 import dev.fabik.bluetoothhid.ui.rememberDialogState
 import dev.fabik.bluetoothhid.ui.tooltip
 import dev.fabik.bluetoothhid.utils.ConnectionMode
@@ -145,14 +152,24 @@ private fun Modifier.iconBackgroundModifier(): Modifier {
     }
 }
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun BoxScope.ElevatedWarningCard(
     message: String,
     subMessage: String? = null,
     onClick: () -> Unit,
+    onDismiss: (() -> Unit)? = null,
     visible: Boolean
 ) {
     val scope = rememberCoroutineScope()
+
+    val dismissState = rememberSwipeToDismissBoxState()
+
+    LaunchedEffect(dismissState.currentValue) {
+        if (dismissState.currentValue != SwipeToDismissBoxValue.Settled) {
+            onDismiss?.invoke()
+        }
+    }
 
     AnimatedVisibility(
         visible = visible, // You will control visibility dynamically
@@ -160,19 +177,26 @@ fun BoxScope.ElevatedWarningCard(
             .padding(12.dp)
             .align(Alignment.TopCenter)
     ) {
-        ElevatedCard(
-            onClick = { scope.launch { onClick() } }
+        SwipeToDismissBox(
+            state = dismissState,
+            backgroundContent = {},
+            enableDismissFromStartToEnd = onDismiss != null,
+            enableDismissFromEndToStart = onDismiss != null,
         ) {
-            Row(
-                Modifier.padding(8.dp),
-                horizontalArrangement = Arrangement.spacedBy(8.dp),
-                verticalAlignment = Alignment.CenterVertically
+            ElevatedCard(
+                onClick = { scope.launch { onClick() } }
             ) {
-                Icon(Icons.Rounded.Warning, contentDescription = "Warning")
-                Column {
-                    Text(message)
-                    subMessage?.let {
-                        Text(it, style = MaterialTheme.typography.bodySmall)
+                Row(
+                    Modifier.padding(8.dp),
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Icon(Icons.Rounded.Warning, contentDescription = "Warning")
+                    Column {
+                        Text(message)
+                        subMessage?.let {
+                            Text(it, style = MaterialTheme.typography.bodySmall)
+                        }
                     }
                 }
             }
@@ -347,6 +371,50 @@ fun Scanner(
                 ZoomStateInfo(it)
             }
             KeepScreenOn()
+
+            // Multi-code picker: visible when multi-code detection is on but auto-send is off
+            val multiCodeDetection by context.getPreferenceState(PreferenceStore.MULTI_CODE_DETECTION)
+            val autoSend by context.getPreferenceState(PreferenceStore.AUTO_SEND)
+            if (multiCodeDetection == true && autoSend != true) {
+                val detectedBarcodes by cameraVM.detectedBarcodes.collectAsStateWithLifecycle()
+                if (detectedBarcodes.isNotEmpty()) {
+                    MultiCodePicker(
+                        barcodes = detectedBarcodes,
+                        modifier = Modifier
+                            .align(Alignment.BottomCenter)
+                            .padding(bottom = 80.dp),
+                        onSelect = { cameraVM.selectBarcode(it) }
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun MultiCodePicker(
+    barcodes: List<Barcode>,
+    modifier: Modifier = Modifier,
+    onSelect: (Barcode) -> Unit
+) {
+    LazyRow(
+        modifier = modifier
+            .fillMaxWidth()
+            .background(Color.Black.copy(alpha = 0.6f))
+            .padding(horizontal = 8.dp, vertical = 4.dp),
+        horizontalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+        items(barcodes) { barcode ->
+            SuggestionChip(
+                onClick = { onSelect(barcode) },
+                label = {
+                    Text(
+                        text = barcode.value?.take(24) ?: "?",
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                }
+            )
         }
     }
 }
@@ -825,6 +893,9 @@ fun BoxScope.DeviceStatusIndicator() {
         val connectionMode by context.getPreferenceState(PreferenceStore.CONNECTION_MODE)
         val isRFCOMMListening by controller.isRFCOMMListeningFlow.collectAsStateWithLifecycle()
 
+        // Dismissed state resets when the device changes or user leaves the scanner
+        var dismissed by remember(currentDevice) { mutableStateOf(false) }
+
         when {
             currentDevice == null -> {
                 // No device selected - show "No device connected" regardless of mode
@@ -834,7 +905,8 @@ fun BoxScope.DeviceStatusIndicator() {
                     onClick = {
                         navigation.navigateUp()
                     },
-                    visible = true
+                    onDismiss = { dismissed = true },
+                    visible = !dismissed
                 )
             }
 
@@ -850,7 +922,8 @@ fun BoxScope.DeviceStatusIndicator() {
                         // Do nothing - this is just an informational message
                         // User has already selected a device and server is listening
                     },
-                    visible = true
+                    onDismiss = { dismissed = true },
+                    visible = !dismissed
                 )
             }
         }

--- a/app/src/main/java/dev/fabik/bluetoothhid/Settings.kt
+++ b/app/src/main/java/dev/fabik/bluetoothhid/Settings.kt
@@ -55,12 +55,14 @@ import androidx.compose.material.icons.filled.Vibration
 import androidx.compose.material.icons.filled.VideoStable
 import androidx.compose.material.icons.filled.ZoomIn
 import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.VerticalDivider
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
@@ -71,12 +73,17 @@ import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.stateDescription
 import androidx.compose.ui.unit.dp
+import androidx.compose.foundation.clickable
+import androidx.compose.material.icons.filled.Layers
+import androidx.compose.material3.ListItem
+import androidx.compose.ui.res.stringResource
 import dev.fabik.bluetoothhid.ui.AdvancedOptionsModal
 import dev.fabik.bluetoothhid.ui.ButtonPreference
 import dev.fabik.bluetoothhid.ui.CheckBoxPreference
 import dev.fabik.bluetoothhid.ui.ComboBoxEnumPreference
 import dev.fabik.bluetoothhid.ui.CustomKeysDialog
 import dev.fabik.bluetoothhid.ui.JavaScriptEditorDialog
+import dev.fabik.bluetoothhid.ui.ProfileManageDialog
 import dev.fabik.bluetoothhid.ui.SaveScanImageOptionsModal
 import dev.fabik.bluetoothhid.ui.SliderPreference
 import dev.fabik.bluetoothhid.ui.SwitchPreference
@@ -85,9 +92,11 @@ import dev.fabik.bluetoothhid.ui.VolumeKeyOptionsModal
 import dev.fabik.bluetoothhid.ui.rememberDialogState
 import dev.fabik.bluetoothhid.utils.ConnectionMode
 import dev.fabik.bluetoothhid.utils.PreferenceStore
+import dev.fabik.bluetoothhid.utils.ProfileManager
 import dev.fabik.bluetoothhid.utils.rememberEnumPreference
 import dev.fabik.bluetoothhid.utils.rememberPreferenceNull
 import dev.fabik.bluetoothhid.utils.setPreference
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import kotlinx.coroutines.launch
 
 @Composable
@@ -104,6 +113,12 @@ fun SettingsContent() {
             .fillMaxSize()
             .padding(0.dp, 0.dp)
     ) {
+        item(contentType = "section") {
+            SectionTitle(strings[R.string.profiles])
+            ProfileSettings()
+            ColoredDivider()
+        }
+
         item(contentType = "section") {
             SectionTitle(strings[R.string.connection])
             ConnectionSettings(strings)
@@ -571,6 +586,13 @@ internal fun ScannerSettings(strings: SettingsStrings) {
         preference = PreferenceStore.PERSIST_HISTORY,
     )
 
+    SwitchPreference(
+        title = strings[R.string.multi_code_detection],
+        desc = strings[R.string.multi_code_detection_desc],
+        icon = Icons.Default.QrCode2,
+        preference = PreferenceStore.MULTI_CODE_DETECTION
+    )
+
     SaveScanImageOptionsModal()
 }
 
@@ -647,6 +669,24 @@ internal fun AboutSettings(strings: SettingsStrings) {
 }
 
 // Cached strings to avoid repeated resource lookups during scroll
+@Composable
+internal fun ProfileSettings() {
+    val context = LocalContext.current
+    val activeProfile by ProfileManager.activeProfile.collectAsStateWithLifecycle()
+    var showManageDialog by remember { mutableStateOf(false) }
+
+    ListItem(
+        headlineContent = { Text(activeProfile) },
+        supportingContent = { Text(stringResource(R.string.active_profile_desc)) },
+        leadingContent = { Icon(Icons.Default.Layers, contentDescription = null) },
+        modifier = Modifier.clickable { showManageDialog = true }
+    )
+
+    if (showManageDialog) {
+        ProfileManageDialog(onDismiss = { showManageDialog = false })
+    }
+}
+
 internal class SettingsStrings(private val context: Context) {
     private val stringCache = mutableMapOf<Int, String>()
     private val arrayCache = mutableMapOf<Int, Array<String>>()

--- a/app/src/main/java/dev/fabik/bluetoothhid/Settings.kt
+++ b/app/src/main/java/dev/fabik/bluetoothhid/Settings.kt
@@ -62,7 +62,6 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.VerticalDivider
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
@@ -73,9 +72,7 @@ import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.stateDescription
 import androidx.compose.ui.unit.dp
-import androidx.compose.foundation.clickable
 import androidx.compose.material.icons.filled.Layers
-import androidx.compose.material3.ListItem
 import androidx.compose.ui.res.stringResource
 import dev.fabik.bluetoothhid.ui.AdvancedOptionsModal
 import dev.fabik.bluetoothhid.ui.ButtonPreference
@@ -671,20 +668,17 @@ internal fun AboutSettings(strings: SettingsStrings) {
 // Cached strings to avoid repeated resource lookups during scroll
 @Composable
 internal fun ProfileSettings() {
-    val context = LocalContext.current
     val activeProfile by ProfileManager.activeProfile.collectAsStateWithLifecycle()
-    var showManageDialog by remember { mutableStateOf(false) }
+    val dialogState = rememberDialogState()
 
-    ListItem(
-        headlineContent = { Text(activeProfile) },
-        supportingContent = { Text(stringResource(R.string.active_profile_desc)) },
-        leadingContent = { Icon(Icons.Default.Layers, contentDescription = null) },
-        modifier = Modifier.clickable { showManageDialog = true }
+    ProfileManageDialog(dialogState)
+
+    ButtonPreference(
+        title = activeProfile,
+        desc = stringResource(R.string.active_profile_desc),
+        icon = Icons.Default.Layers,
+        onClick = dialogState::open
     )
-
-    if (showManageDialog) {
-        ProfileManageDialog(onDismiss = { showManageDialog = false })
-    }
 }
 
 internal class SettingsStrings(private val context: Context) {

--- a/app/src/main/java/dev/fabik/bluetoothhid/SettingsActivity.kt
+++ b/app/src/main/java/dev/fabik/bluetoothhid/SettingsActivity.kt
@@ -20,11 +20,17 @@ import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.res.stringResource
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import dev.fabik.bluetoothhid.ui.SettingsDropdown
 import dev.fabik.bluetoothhid.ui.theme.BluetoothHIDTheme
 import dev.fabik.bluetoothhid.ui.theme.configureWindow
 import dev.fabik.bluetoothhid.ui.tooltip
+import dev.fabik.bluetoothhid.utils.LocalDataStore
+import dev.fabik.bluetoothhid.utils.ProfileManager
 
 class SettingsActivity : ComponentActivity() {
 
@@ -38,32 +44,37 @@ class SettingsActivity : ComponentActivity() {
         configureWindow(window)
 
         setContent {
-            BluetoothHIDTheme(window = window) {
-                Surface(Modifier.fillMaxSize()) {
-                    val scrollBehavior = TopAppBarDefaults.pinnedScrollBehavior()
+            val activeDataStore by remember { ProfileManager.activeStoreFlow(applicationContext) }
+                .collectAsStateWithLifecycle(initialValue = ProfileManager.currentStore(applicationContext))
 
-                    Scaffold(
-                        modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
-                        topBar = {
-                            TopAppBar(
-                                title = { Text(stringResource(R.string.settings)) },
-                                navigationIcon = {
-                                    IconButton(
-                                        onClick = { finishAfterTransition() },
-                                        Modifier.tooltip(stringResource(R.string.back))
-                                    ) {
-                                        Icon(Icons.AutoMirrored.Filled.ArrowBack, "Back")
-                                    }
-                                },
-                                actions = {
-                                    SettingsDropdown()
-                                },
-                                scrollBehavior = scrollBehavior
-                            )
-                        }
-                    ) { padding ->
-                        Box(Modifier.padding(padding)) {
-                            SettingsContent()
+            CompositionLocalProvider(LocalDataStore provides activeDataStore) {
+                BluetoothHIDTheme(window = window) {
+                    Surface(Modifier.fillMaxSize()) {
+                        val scrollBehavior = TopAppBarDefaults.pinnedScrollBehavior()
+
+                        Scaffold(
+                            modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
+                            topBar = {
+                                TopAppBar(
+                                    title = { Text(stringResource(R.string.settings)) },
+                                    navigationIcon = {
+                                        IconButton(
+                                            onClick = { finishAfterTransition() },
+                                            Modifier.tooltip(stringResource(R.string.back))
+                                        ) {
+                                            Icon(Icons.AutoMirrored.Filled.ArrowBack, "Back")
+                                        }
+                                    },
+                                    actions = {
+                                        SettingsDropdown()
+                                    },
+                                    scrollBehavior = scrollBehavior
+                                )
+                            }
+                        ) { padding ->
+                            Box(Modifier.padding(padding)) {
+                                SettingsContent()
+                            }
                         }
                     }
                 }

--- a/app/src/main/java/dev/fabik/bluetoothhid/ui/CameraOverlay.kt
+++ b/app/src/main/java/dev/fabik/bluetoothhid/ui/CameraOverlay.kt
@@ -7,7 +7,6 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.absoluteOffset
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.DragIndicator
 import androidx.compose.material.icons.filled.OpenInFull
@@ -18,7 +17,6 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -66,6 +64,31 @@ fun OverlayCanvas(viewModel: CameraViewModel) {
     val currentBarcode by viewModel.currentBarcode.collectAsStateWithLifecycle()
     val detectedBarcodes by viewModel.detectedBarcodes.collectAsStateWithLifecycle()
 
+    LaunchedEffect(Unit) {
+        val json = context.getPreference(PreferenceStore.SCAN_AREAS).first()
+        val loaded = if (json.isBlank()) {
+            // Migrate from legacy single-area prefs
+            val posX = context.getPreference(PreferenceStore.OVERLAY_POS_X).first()
+            val posY = context.getPreference(PreferenceStore.OVERLAY_POS_Y).first()
+            val sizeX = context.getPreference(PreferenceStore.OVERLAY_WIDTH).first()
+            val sizeY = context.getPreference(PreferenceStore.OVERLAY_HEIGHT).first()
+            listOf(ScanAreaData(posX, posY, sizeX, sizeY))
+        } else {
+            ScanAreaData.fromJsonArray(json).ifEmpty { listOf(ScanAreaData.DEFAULT) }
+        }
+        viewModel.areas.clear()
+        viewModel.areas.addAll(loaded)
+        // Keep legacy fields in sync with first area for debug overlay
+        viewModel.overlayPosition = Offset(viewModel.areas[0].posX, viewModel.areas[0].posY)
+        viewModel.overlaySize = Size(viewModel.areas[0].sizeX, viewModel.areas[0].sizeY)
+    }
+
+    fun saveState() {
+        runBlocking {
+            context.setPreference(PreferenceStore.SCAN_AREAS, ScanAreaData.toJsonArray(viewModel.areas))
+        }
+    }
+
     Canvas(
         Modifier
             .fillMaxSize()
@@ -93,7 +116,7 @@ fun OverlayCanvas(viewModel: CameraViewModel) {
 
                 // Custom — user adjustable, supports multiple areas
                 OverlayType.CUSTOM -> {
-                    val rects = viewModel.scanAreas.map { it.toRect(this.size.width, this.size.height) }
+                    val rects = viewModel.areas.map { it.toRect(this.size.width, this.size.height) }
                     viewModel.scanRects = rects
                     when {
                         rects.isEmpty() -> Rect.Zero
@@ -155,7 +178,7 @@ fun OverlayCanvas(viewModel: CameraViewModel) {
     // Show the adjust buttons
     if (restrictArea && overlayType == OverlayType.CUSTOM) {
         Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-            CustomOverlayButtons(viewModel)
+            CustomOverlayButtons(viewModel, ::saveState)
         }
     }
 
@@ -166,40 +189,15 @@ fun OverlayCanvas(viewModel: CameraViewModel) {
 }
 
 @Composable
-fun CustomOverlayButtons(viewModel: CameraViewModel) {
-    val context = LocalContext.current
-    val areas = remember { mutableStateListOf<ScanAreaData>() }
-
-    LaunchedEffect(Unit) {
-        val json = context.getPreference(PreferenceStore.SCAN_AREAS).first()
-        val loaded = if (json.isBlank()) {
-            // Migrate from legacy single-area prefs
-            val posX = context.getPreference(PreferenceStore.OVERLAY_POS_X).first()
-            val posY = context.getPreference(PreferenceStore.OVERLAY_POS_Y).first()
-            val sizeX = context.getPreference(PreferenceStore.OVERLAY_WIDTH).first()
-            val sizeY = context.getPreference(PreferenceStore.OVERLAY_HEIGHT).first()
-            listOf(ScanAreaData(posX, posY, sizeX, sizeY))
-        } else {
-            ScanAreaData.fromJsonArray(json).ifEmpty { listOf(ScanAreaData.DEFAULT) }
-        }
-        areas.clear()
-        areas.addAll(loaded)
-        viewModel.scanAreas = areas.toList()
-        // Keep legacy fields in sync with first area for debug overlay
-        viewModel.overlayPosition = Offset(areas[0].posX, areas[0].posY)
-        viewModel.overlaySize = Size(areas[0].sizeX, areas[0].sizeY)
-    }
-
-    fun saveState() {
-        runBlocking {
-            context.setPreference(PreferenceStore.SCAN_AREAS, ScanAreaData.toJsonArray(areas))
-        }
-    }
+fun CustomOverlayButtons(
+    viewModel: CameraViewModel,
+    saveState: () -> Unit
+) {
+    val areas = viewModel.areas
 
     fun reset() {
         areas.clear()
         areas.add(ScanAreaData.DEFAULT)
-        viewModel.scanAreas = areas.toList()
         viewModel.overlayPosition = Offset(ScanAreaData.DEFAULT.posX, ScanAreaData.DEFAULT.posY)
         viewModel.overlaySize = Size(ScanAreaData.DEFAULT.sizeX, ScanAreaData.DEFAULT.sizeY)
         saveState()
@@ -222,13 +220,12 @@ fun CustomOverlayButtons(viewModel: CameraViewModel) {
                     )
                 }
                 .pointerInput(areas.size) {
-                    detectDragGestures(onDragEnd = ::saveState) { change, dragAmount ->
+                    detectDragGestures(onDragEnd = saveState) { change, dragAmount ->
                         change.consume()
                         areas[index] = areas[index].copy(
                             sizeX = areas[index].sizeX + dragAmount.x,
                             sizeY = areas[index].sizeY + dragAmount.y
                         )
-                        viewModel.scanAreas = areas.toList()
                     }
                 }
         ) {
@@ -247,13 +244,12 @@ fun CustomOverlayButtons(viewModel: CameraViewModel) {
                     )
                 }
                 .pointerInput(areas.size) {
-                    detectDragGestures(onDragEnd = ::saveState) { change, dragAmount ->
+                    detectDragGestures(onDragEnd = saveState) { change, dragAmount ->
                         change.consume()
                         areas[index] = areas[index].copy(
                             posX = areas[index].posX + dragAmount.x,
                             posY = areas[index].posY + dragAmount.y
                         )
-                        viewModel.scanAreas = areas.toList()
                         // Keep legacy fields in sync with first area for debug overlay
                         if (index == 0) {
                             viewModel.overlayPosition = Offset(areas[0].posX, areas[0].posY)
@@ -270,7 +266,6 @@ fun CustomOverlayButtons(viewModel: CameraViewModel) {
             IconButton(
                 onClick = {
                     areas.removeAt(index)
-                    viewModel.scanAreas = areas.toList()
                     saveState()
                 },
                 colors = iconColors,
@@ -286,21 +281,6 @@ fun CustomOverlayButtons(viewModel: CameraViewModel) {
         }
     }
 
-    // Add area button — fixed offset from center so it doesn't overlap with handles
-    IconButton(
-        onClick = {
-            val offset = areas.size * 40f
-            areas.add(ScanAreaData(offset, offset, 100f, 100f))
-            viewModel.scanAreas = areas.toList()
-            saveState()
-        },
-        colors = IconButtonDefaults.iconButtonColors(
-            MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.8f)
-        ),
-        modifier = Modifier.absoluteOffset { IntOffset(-200, -200) }
-    ) {
-        Icon(Icons.Default.Add, "Add area")
-    }
 }
 
 @Composable

--- a/app/src/main/java/dev/fabik/bluetoothhid/ui/CameraOverlay.kt
+++ b/app/src/main/java/dev/fabik/bluetoothhid/ui/CameraOverlay.kt
@@ -17,7 +17,6 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.CornerRadius
@@ -61,6 +60,8 @@ fun OverlayCanvas(viewModel: CameraViewModel) {
     // val highlightType by rememberPreferenceNull(PreferenceStore.HIGHLIGHT_TYPE)
     val developerMode by context.getPreferenceState(PreferenceStore.DEVELOPER_MODE)
 
+    UpdateScanAreas(viewModel, restrictArea, overlayType)
+
     val currentBarcode by viewModel.currentBarcode.collectAsStateWithLifecycle()
     val detectedBarcodes by viewModel.detectedBarcodes.collectAsStateWithLifecycle()
 
@@ -76,16 +77,16 @@ fun OverlayCanvas(viewModel: CameraViewModel) {
         } else {
             ScanAreaData.fromJsonArray(json).ifEmpty { listOf(ScanAreaData.DEFAULT) }
         }
-        viewModel.areas.clear()
-        viewModel.areas.addAll(loaded)
-        // Keep legacy fields in sync with first area for debug overlay
-        viewModel.overlayPosition = Offset(viewModel.areas[0].posX, viewModel.areas[0].posY)
-        viewModel.overlaySize = Size(viewModel.areas[0].sizeX, viewModel.areas[0].sizeY)
+        viewModel.clearScanAreas()
+        viewModel.addScanAreas(*loaded.toTypedArray())
     }
 
     fun saveState() {
         runBlocking {
-            context.setPreference(PreferenceStore.SCAN_AREAS, ScanAreaData.toJsonArray(viewModel.areas))
+            context.setPreference(
+                PreferenceStore.SCAN_AREAS,
+                ScanAreaData.toJsonArray(viewModel.areas.value)
+            )
         }
     }
 
@@ -95,49 +96,10 @@ fun OverlayCanvas(viewModel: CameraViewModel) {
             .onGloballyPositioned {
                 viewModel.viewSize = it.size
                 viewModel.lastScanSize = null
-            }) {
-        val x = this.size.width / 2
-        val y = this.size.height / 2
-        val landscape = this.size.width > this.size.height
-
+            }
+    ) {
         // Draws the scanner area
         if (restrictArea) {
-            viewModel.scanRect = when (overlayType) {
-                // Rectangle optimized for barcodes
-                OverlayType.RECTANGLE -> {
-                    viewModel.scanRects = emptyList()
-                    val length = this.size.width * 0.8f
-                    val height = (length * 0.45f).coerceAtMost(y * 0.8f)
-                    Rect(
-                        Offset(x - length / 2, y - height / 2),
-                        Size(length, height)
-                    )
-                }
-
-                // Custom — user adjustable, supports multiple areas
-                OverlayType.CUSTOM -> {
-                    val rects = viewModel.areas.map { it.toRect(this.size.width, this.size.height) }
-                    viewModel.scanRects = rects
-                    when {
-                        rects.isEmpty() -> Rect.Zero
-                        rects.size == 1 -> rects.first()
-                        else -> rects.fold(rects.first()) { acc, r ->
-                            Rect(
-                                minOf(acc.left, r.left), minOf(acc.top, r.top),
-                                maxOf(acc.right, r.right), maxOf(acc.bottom, r.bottom)
-                            )
-                        }
-                    }
-                }
-
-                // Square for scanning qr codes (default)
-                OverlayType.SQUARE -> {
-                    viewModel.scanRects = emptyList()
-                    val length = if (landscape) this.size.height * 0.6f else this.size.width * 0.8f
-                    Rect(Offset(x - length / 2, y - length / 2), Size(length, length))
-                }
-            }
-
             val markerPath = Path().apply {
                 if (viewModel.scanRects.isNotEmpty()) {
                     // Draw each custom area as a separate rounded rect cutout
@@ -189,17 +151,70 @@ fun OverlayCanvas(viewModel: CameraViewModel) {
 }
 
 @Composable
+fun UpdateScanAreas(
+    viewModel: CameraViewModel,
+    restrictArea: Boolean,
+    overlayType: OverlayType
+) {
+    LaunchedEffect(viewModel.viewSize, restrictArea, overlayType) {
+        if (!restrictArea) return@LaunchedEffect
+        viewModel.viewSize?.let {
+            val x = it.width / 2
+            val y = it.height / 2
+            val landscape = it.width > it.height
+
+            viewModel.areas.collect { scanAreas ->
+                viewModel.scanRect = when (overlayType) {
+                    // Rectangle optimized for barcodes
+                    OverlayType.RECTANGLE -> {
+                        viewModel.scanRects = emptyList()
+                        val length = it.width * 0.8f
+                        val height = (length * 0.45f).coerceAtMost(y * 0.8f)
+                        Rect(
+                            Offset(x - length / 2, y - height / 2),
+                            Size(length, height)
+                        )
+                    }
+
+                    // Custom — user adjustable, supports multiple areas
+                    OverlayType.CUSTOM -> {
+                        val rects =
+                            scanAreas.map { a -> a.toRect(it.width.toFloat(), it.height.toFloat()) }
+                        viewModel.scanRects = rects
+                        when {
+                            rects.isEmpty() -> Rect.Zero
+                            rects.size == 1 -> rects.first()
+                            else -> rects.fold(rects.first()) { acc, r ->
+                                Rect(
+                                    minOf(acc.left, r.left), minOf(acc.top, r.top),
+                                    maxOf(acc.right, r.right), maxOf(acc.bottom, r.bottom)
+                                )
+                            }
+                        }
+                    }
+
+                    // Square for scanning qr codes (default)
+                    OverlayType.SQUARE -> {
+                        viewModel.scanRects = emptyList()
+                        val length = if (landscape) it.height * 0.6f else it.width * 0.8f
+                        Rect(Offset(x - length / 2, y - length / 2), Size(length, length))
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
 fun CustomOverlayButtons(
     viewModel: CameraViewModel,
     saveState: () -> Unit
 ) {
-    val areas = viewModel.areas
+    val scanAreas by viewModel.areas.collectAsStateWithLifecycle()
 
     fun reset() {
-        areas.clear()
-        areas.add(ScanAreaData.DEFAULT)
-        viewModel.overlayPosition = Offset(ScanAreaData.DEFAULT.posX, ScanAreaData.DEFAULT.posY)
-        viewModel.overlaySize = Size(ScanAreaData.DEFAULT.sizeX, ScanAreaData.DEFAULT.sizeY)
+        viewModel.clearScanAreas()
+        viewModel.addScanAreas(ScanAreaData.DEFAULT)
         saveState()
     }
 
@@ -207,7 +222,7 @@ fun CustomOverlayButtons(
         MaterialTheme.colorScheme.surface.copy(alpha = 0.5f)
     )
 
-    areas.forEachIndexed { index, area ->
+    scanAreas.forEachIndexed { index, area ->
         // Resize handle — bottom-right corner of this area
         IconButton(
             onClick = ::reset,
@@ -219,12 +234,14 @@ fun CustomOverlayButtons(
                         (area.posY + area.sizeY.absoluteValue).roundToInt()
                     )
                 }
-                .pointerInput(areas.size) {
+                .pointerInput(scanAreas.size) {
                     detectDragGestures(onDragEnd = saveState) { change, dragAmount ->
                         change.consume()
-                        areas[index] = areas[index].copy(
-                            sizeX = areas[index].sizeX + dragAmount.x,
-                            sizeY = areas[index].sizeY + dragAmount.y
+                        viewModel.updateScanArea(
+                            index, scanAreas[index].copy(
+                                sizeX = scanAreas[index].sizeX + dragAmount.x,
+                                sizeY = scanAreas[index].sizeY + dragAmount.y
+                            )
                         )
                     }
                 }
@@ -243,18 +260,15 @@ fun CustomOverlayButtons(
                         (area.posY + area.sizeY.absoluteValue).roundToInt()
                     )
                 }
-                .pointerInput(areas.size) {
+                .pointerInput(scanAreas.size) {
                     detectDragGestures(onDragEnd = saveState) { change, dragAmount ->
                         change.consume()
-                        areas[index] = areas[index].copy(
-                            posX = areas[index].posX + dragAmount.x,
-                            posY = areas[index].posY + dragAmount.y
+                        viewModel.updateScanArea(
+                            index, scanAreas[index].copy(
+                                posX = scanAreas[index].posX + dragAmount.x,
+                                posY = scanAreas[index].posY + dragAmount.y
+                            )
                         )
-                        // Keep legacy fields in sync with first area for debug overlay
-                        if (index == 0) {
-                            viewModel.overlayPosition = Offset(areas[0].posX, areas[0].posY)
-                            viewModel.overlaySize = Size(areas[0].sizeX, areas[0].sizeY)
-                        }
                     }
                 }
         ) {
@@ -262,10 +276,10 @@ fun CustomOverlayButtons(
         }
 
         // Delete button — top-right corner, only shown when multiple areas exist
-        if (areas.size > 1) {
+        if (scanAreas.size > 1) {
             IconButton(
                 onClick = {
-                    areas.removeAt(index)
+                    viewModel.removeScanArea(index)
                     saveState()
                 },
                 colors = iconColors,

--- a/app/src/main/java/dev/fabik/bluetoothhid/ui/CameraOverlay.kt
+++ b/app/src/main/java/dev/fabik/bluetoothhid/ui/CameraOverlay.kt
@@ -7,6 +7,8 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.absoluteOffset
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.DragIndicator
 import androidx.compose.material.icons.filled.OpenInFull
 import androidx.compose.material3.Icon
@@ -16,9 +18,8 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.CornerRadius
@@ -41,6 +42,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import dev.fabik.bluetoothhid.ui.model.CameraViewModel
 import dev.fabik.bluetoothhid.utils.OverlayType
 import dev.fabik.bluetoothhid.utils.PreferenceStore
+import dev.fabik.bluetoothhid.utils.ScanAreaData
 import dev.fabik.bluetoothhid.utils.getPreference
 import dev.fabik.bluetoothhid.utils.getPreferenceState
 import dev.fabik.bluetoothhid.utils.getPreferenceStateBlocking
@@ -62,6 +64,7 @@ fun OverlayCanvas(viewModel: CameraViewModel) {
     val developerMode by context.getPreferenceState(PreferenceStore.DEVELOPER_MODE)
 
     val currentBarcode by viewModel.currentBarcode.collectAsStateWithLifecycle()
+    val detectedBarcodes by viewModel.detectedBarcodes.collectAsStateWithLifecycle()
 
     Canvas(
         Modifier
@@ -79,6 +82,7 @@ fun OverlayCanvas(viewModel: CameraViewModel) {
             viewModel.scanRect = when (overlayType) {
                 // Rectangle optimized for barcodes
                 OverlayType.RECTANGLE -> {
+                    viewModel.scanRects = emptyList()
                     val length = this.size.width * 0.8f
                     val height = (length * 0.45f).coerceAtMost(y * 0.8f)
                     Rect(
@@ -87,34 +91,39 @@ fun OverlayCanvas(viewModel: CameraViewModel) {
                     )
                 }
 
-                // Custom - user adjustable overlay
+                // Custom — user adjustable, supports multiple areas
                 OverlayType.CUSTOM -> {
-                    val pos = viewModel.overlayPosition
-                    val size = viewModel.overlaySize
-
-                    if (pos != null && size != null)
-                        Rect(
-                            pos + Offset(
-                                x - size.width.absoluteValue,
-                                y - size.height.absoluteValue
-                            ),
-                            pos + Offset(
-                                x + size.width.absoluteValue,
-                                y + size.height.absoluteValue
+                    val rects = viewModel.scanAreas.map { it.toRect(this.size.width, this.size.height) }
+                    viewModel.scanRects = rects
+                    when {
+                        rects.isEmpty() -> Rect.Zero
+                        rects.size == 1 -> rects.first()
+                        else -> rects.fold(rects.first()) { acc, r ->
+                            Rect(
+                                minOf(acc.left, r.left), minOf(acc.top, r.top),
+                                maxOf(acc.right, r.right), maxOf(acc.bottom, r.bottom)
                             )
-                        )
-                    else Rect.Zero
+                        }
+                    }
                 }
 
                 // Square for scanning qr codes (default)
                 OverlayType.SQUARE -> {
+                    viewModel.scanRects = emptyList()
                     val length = if (landscape) this.size.height * 0.6f else this.size.width * 0.8f
                     Rect(Offset(x - length / 2, y - length / 2), Size(length, length))
                 }
             }
 
             val markerPath = Path().apply {
-                addRoundRect(RoundRect(viewModel.scanRect, CornerRadius(30f)))
+                if (viewModel.scanRects.isNotEmpty()) {
+                    // Draw each custom area as a separate rounded rect cutout
+                    viewModel.scanRects.forEach { rect ->
+                        addRoundRect(RoundRect(rect, CornerRadius(30f)))
+                    }
+                } else {
+                    addRoundRect(RoundRect(viewModel.scanRect, CornerRadius(30f)))
+                }
             }
 
             clipPath(markerPath, clipOp = ClipOp.Difference) {
@@ -124,21 +133,22 @@ fun OverlayCanvas(viewModel: CameraViewModel) {
             drawPath(markerPath, color = Color.White, style = Stroke(5f))
         } else {
             viewModel.scanRect = Rect(Offset(0f, 0f), size)
+            viewModel.scanRects = emptyList()
         }
 
-        // Highlights the current barcode on screen (with a rectangle)
-        currentBarcode?.let {
-            // Draw a rectangle around the barcode
+        // In multi-code mode: highlight all detected barcodes; current = blue, others = yellow
+        // In single-code mode: only currentBarcode is shown (detectedBarcodes has at most 1 item)
+        detectedBarcodes.forEach { barcode ->
+            val isActive = barcode.value != null && barcode.value == currentBarcode?.value
+            val color = if (isActive) Color.Blue else Color.Yellow
             val path = Path().apply {
-                it.cornerPoints.forEach { p ->
-                    if (isEmpty)
-                        moveTo(p.x, p.y)
+                barcode.cornerPoints.forEach { p ->
+                    if (isEmpty) moveTo(p.x, p.y)
                     lineTo(p.x, p.y)
                 }
                 close()
             }
-
-            drawPath(path, color = Color.Blue, style = Stroke(5f))
+            drawPath(path, color = color, style = Stroke(5f))
         }
     }
 
@@ -158,111 +168,138 @@ fun OverlayCanvas(viewModel: CameraViewModel) {
 @Composable
 fun CustomOverlayButtons(viewModel: CameraViewModel) {
     val context = LocalContext.current
-    var posOffsetX by remember {
-        mutableFloatStateOf(runBlocking {
-            context.getPreference(
-                PreferenceStore.OVERLAY_POS_X
-            ).first()
-        })
-    }
-    var posOffsetY by remember {
-        mutableFloatStateOf(runBlocking {
-            context.getPreference(
-                PreferenceStore.OVERLAY_POS_Y
-            ).first()
-        })
-    }
-    var sizeOffsetX by remember {
-        mutableFloatStateOf(runBlocking {
-            context.getPreference(
-                PreferenceStore.OVERLAY_WIDTH
-            ).first()
-        })
-    }
-    var sizeOffsetY by remember {
-        mutableFloatStateOf(runBlocking {
-            context.getPreference(
-                PreferenceStore.OVERLAY_HEIGHT
-            ).first()
-        })
-    }
+    val areas = remember { mutableStateListOf<ScanAreaData>() }
 
     LaunchedEffect(Unit) {
-        viewModel.overlayPosition = Offset(posOffsetX, posOffsetY)
-        viewModel.overlaySize = Size(sizeOffsetX, sizeOffsetY)
+        val json = context.getPreference(PreferenceStore.SCAN_AREAS).first()
+        val loaded = if (json.isBlank()) {
+            // Migrate from legacy single-area prefs
+            val posX = context.getPreference(PreferenceStore.OVERLAY_POS_X).first()
+            val posY = context.getPreference(PreferenceStore.OVERLAY_POS_Y).first()
+            val sizeX = context.getPreference(PreferenceStore.OVERLAY_WIDTH).first()
+            val sizeY = context.getPreference(PreferenceStore.OVERLAY_HEIGHT).first()
+            listOf(ScanAreaData(posX, posY, sizeX, sizeY))
+        } else {
+            ScanAreaData.fromJsonArray(json).ifEmpty { listOf(ScanAreaData.DEFAULT) }
+        }
+        areas.clear()
+        areas.addAll(loaded)
+        viewModel.scanAreas = areas.toList()
+        // Keep legacy fields in sync with first area for debug overlay
+        viewModel.overlayPosition = Offset(areas[0].posX, areas[0].posY)
+        viewModel.overlaySize = Size(areas[0].sizeX, areas[0].sizeY)
     }
 
     fun saveState() {
         runBlocking {
-            context.setPreference(PreferenceStore.OVERLAY_POS_X, posOffsetX)
-            context.setPreference(PreferenceStore.OVERLAY_POS_Y, posOffsetY)
-            context.setPreference(PreferenceStore.OVERLAY_WIDTH, sizeOffsetX)
-            context.setPreference(PreferenceStore.OVERLAY_HEIGHT, sizeOffsetY)
+            context.setPreference(PreferenceStore.SCAN_AREAS, ScanAreaData.toJsonArray(areas))
         }
     }
 
     fun reset() {
-        posOffsetX = PreferenceStore.OVERLAY_POS_X.defaultValue
-        posOffsetY = PreferenceStore.OVERLAY_POS_Y.defaultValue
-        sizeOffsetX = PreferenceStore.OVERLAY_WIDTH.defaultValue
-        sizeOffsetY = PreferenceStore.OVERLAY_HEIGHT.defaultValue
-
-        viewModel.overlayPosition = Offset(posOffsetX, posOffsetY)
-        viewModel.overlaySize = Size(sizeOffsetX, sizeOffsetY)
-
+        areas.clear()
+        areas.add(ScanAreaData.DEFAULT)
+        viewModel.scanAreas = areas.toList()
+        viewModel.overlayPosition = Offset(ScanAreaData.DEFAULT.posX, ScanAreaData.DEFAULT.posY)
+        viewModel.overlaySize = Size(ScanAreaData.DEFAULT.sizeX, ScanAreaData.DEFAULT.sizeY)
         saveState()
     }
 
-    IconButton(
-        onClick = ::reset,
-        colors = IconButtonDefaults.iconButtonColors(
-            MaterialTheme.colorScheme.surface.copy(
-                alpha = 0.5f
-            )
-        ),
-        modifier = Modifier
-            .absoluteOffset {
-                IntOffset(
-                    (posOffsetX + sizeOffsetX).roundToInt(),
-                    (posOffsetY + sizeOffsetY).roundToInt()
-                )
-            }
-            .pointerInput(Unit) {
-                detectDragGestures(onDragEnd = ::saveState) { change, dragAmount ->
-                    change.consume()
-                    sizeOffsetX += dragAmount.x
-                    sizeOffsetY += dragAmount.y
-                    viewModel.overlaySize = Size(sizeOffsetX, sizeOffsetY)
+    val iconColors = IconButtonDefaults.iconButtonColors(
+        MaterialTheme.colorScheme.surface.copy(alpha = 0.5f)
+    )
+
+    areas.forEachIndexed { index, area ->
+        // Resize handle — bottom-right corner of this area
+        IconButton(
+            onClick = ::reset,
+            colors = iconColors,
+            modifier = Modifier
+                .absoluteOffset {
+                    IntOffset(
+                        (area.posX + area.sizeX.absoluteValue).roundToInt(),
+                        (area.posY + area.sizeY.absoluteValue).roundToInt()
+                    )
                 }
+                .pointerInput(areas.size) {
+                    detectDragGestures(onDragEnd = ::saveState) { change, dragAmount ->
+                        change.consume()
+                        areas[index] = areas[index].copy(
+                            sizeX = areas[index].sizeX + dragAmount.x,
+                            sizeY = areas[index].sizeY + dragAmount.y
+                        )
+                        viewModel.scanAreas = areas.toList()
+                    }
+                }
+        ) {
+            Icon(Icons.Default.OpenInFull, "Modify size")
+        }
+
+        // Move handle — bottom-left corner of this area
+        IconButton(
+            onClick = ::reset,
+            colors = iconColors,
+            modifier = Modifier
+                .absoluteOffset {
+                    IntOffset(
+                        (area.posX - area.sizeX.absoluteValue).roundToInt(),
+                        (area.posY + area.sizeY.absoluteValue).roundToInt()
+                    )
+                }
+                .pointerInput(areas.size) {
+                    detectDragGestures(onDragEnd = ::saveState) { change, dragAmount ->
+                        change.consume()
+                        areas[index] = areas[index].copy(
+                            posX = areas[index].posX + dragAmount.x,
+                            posY = areas[index].posY + dragAmount.y
+                        )
+                        viewModel.scanAreas = areas.toList()
+                        // Keep legacy fields in sync with first area for debug overlay
+                        if (index == 0) {
+                            viewModel.overlayPosition = Offset(areas[0].posX, areas[0].posY)
+                            viewModel.overlaySize = Size(areas[0].sizeX, areas[0].sizeY)
+                        }
+                    }
+                }
+        ) {
+            Icon(Icons.Default.DragIndicator, "Modify position")
+        }
+
+        // Delete button — top-right corner, only shown when multiple areas exist
+        if (areas.size > 1) {
+            IconButton(
+                onClick = {
+                    areas.removeAt(index)
+                    viewModel.scanAreas = areas.toList()
+                    saveState()
+                },
+                colors = iconColors,
+                modifier = Modifier.absoluteOffset {
+                    IntOffset(
+                        (area.posX + area.sizeX.absoluteValue).roundToInt(),
+                        (area.posY - area.sizeY.absoluteValue).roundToInt()
+                    )
+                }
+            ) {
+                Icon(Icons.Default.Close, "Delete area")
             }
-    ) {
-        Icon(Icons.Default.OpenInFull, "Modify size")
+        }
     }
 
+    // Add area button — fixed offset from center so it doesn't overlap with handles
     IconButton(
-        onClick = ::reset,
+        onClick = {
+            val offset = areas.size * 40f
+            areas.add(ScanAreaData(offset, offset, 100f, 100f))
+            viewModel.scanAreas = areas.toList()
+            saveState()
+        },
         colors = IconButtonDefaults.iconButtonColors(
-            MaterialTheme.colorScheme.surface.copy(
-                alpha = 0.5f
-            )
+            MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.8f)
         ),
-        modifier = Modifier
-            .absoluteOffset {
-                IntOffset(
-                    (posOffsetX - sizeOffsetX).roundToInt(),
-                    (posOffsetY + sizeOffsetY).roundToInt()
-                )
-            }
-            .pointerInput(Unit) {
-                detectDragGestures(onDragEnd = ::saveState) { change, dragAmount ->
-                    change.consume()
-                    posOffsetX += dragAmount.x
-                    posOffsetY += dragAmount.y
-                    viewModel.overlayPosition = Offset(posOffsetX, posOffsetY)
-                }
-            }
+        modifier = Modifier.absoluteOffset { IntOffset(-200, -200) }
     ) {
-        Icon(Icons.Default.DragIndicator, "Modify position")
+        Icon(Icons.Default.Add, "Add area")
     }
 }
 

--- a/app/src/main/java/dev/fabik/bluetoothhid/ui/CameraPreview.kt
+++ b/app/src/main/java/dev/fabik/bluetoothhid/ui/CameraPreview.kt
@@ -253,7 +253,9 @@ fun CameraPreviewPreferences(viewModel: CameraViewModel) {
         PreferenceStore.SAVE_SCAN_QUALITY,
         PreferenceStore.SAVE_SCAN_FILE_PATTERN,
         PreferenceStore.CLEAR_AFTER_TIME,
-        PreferenceStore.SAVE_SCAN_IMAGE_FORMAT
+        PreferenceStore.SAVE_SCAN_IMAGE_FORMAT,
+        PreferenceStore.MULTI_CODE_DETECTION,
+        PreferenceStore.AUTO_SEND
     )
 
     scanner?.let {
@@ -278,7 +280,9 @@ fun CameraPreviewPreferences(viewModel: CameraViewModel) {
                 PreferenceStore.SAVE_SCAN_QUALITY.extract(it),
                 PreferenceStore.SAVE_SCAN_FILE_PATTERN.extract(it),
                 PreferenceStore.CLEAR_AFTER_TIME.extractEnum(it).value,
-                PreferenceStore.SAVE_SCAN_IMAGE_FORMAT.extractEnum(it)
+                PreferenceStore.SAVE_SCAN_IMAGE_FORMAT.extractEnum(it),
+                PreferenceStore.MULTI_CODE_DETECTION.extract(it),
+                PreferenceStore.AUTO_SEND.extract(it)
             )
         }
     }

--- a/app/src/main/java/dev/fabik/bluetoothhid/ui/Navigation.kt
+++ b/app/src/main/java/dev/fabik/bluetoothhid/ui/Navigation.kt
@@ -5,6 +5,7 @@ import androidx.activity.compose.BackHandler
 import androidx.activity.compose.LocalActivity
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf

--- a/app/src/main/java/dev/fabik/bluetoothhid/ui/Navigation.kt
+++ b/app/src/main/java/dev/fabik/bluetoothhid/ui/Navigation.kt
@@ -28,6 +28,7 @@ import dev.fabik.bluetoothhid.ui.model.BarcodeResult
 import dev.fabik.bluetoothhid.utils.ZXingAnalyzer
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 
@@ -95,8 +96,12 @@ fun NavGraph() {
             }
 
             composable(Routes.Main) {
-                Scanner(currentDevice) { result: BarcodeResult ->
-                    scope.launch {
+                // Unbounded channel ensures every barcode result is queued even during active sends
+                val sendQueue = remember { Channel<BarcodeResult>(Channel.UNLIMITED) }
+
+                // Sequential queue processor — each sendString awaits completion before next item
+                LaunchedEffect(controller) {
+                    for (result in sendQueue) {
                         val barcodeType = ZXingAnalyzer.index2String(result.format)
                         controller?.sendString(
                             result.text,
@@ -108,6 +113,10 @@ fun NavGraph() {
                             regexGroups = result.regexGroups
                         )
                     }
+                }
+
+                Scanner(currentDevice) { result: BarcodeResult ->
+                    sendQueue.trySend(result)
                 }
 
                 DisposableEffect(Unit) {

--- a/app/src/main/java/dev/fabik/bluetoothhid/ui/Preference.kt
+++ b/app/src/main/java/dev/fabik/bluetoothhid/ui/Preference.kt
@@ -13,7 +13,7 @@ import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.graphics.vector.ImageVector
 import dev.fabik.bluetoothhid.utils.PreferenceStore
 import dev.fabik.bluetoothhid.utils.rememberEnumPreference
-import dev.fabik.bluetoothhid.utils.rememberPreferenceNull
+import dev.fabik.bluetoothhid.utils.rememberPreference
 
 
 @Composable
@@ -46,7 +46,7 @@ fun SwitchPreference(
     enabled: Boolean = true,
     preference: PreferenceStore.Preference<Boolean>
 ) {
-    var checked by rememberPreferenceNull(preference)
+    var checked by rememberPreference(preference)
 
     SwitchPreference(title, desc, icon, checked, enabled) {
         checked = it
@@ -140,7 +140,7 @@ fun SliderPreference(
     enabled: Boolean = true,
     preference: PreferenceStore.Preference<Float>
 ) {
-    var value by rememberPreferenceNull(preference)
+    var value by rememberPreference(preference)
 
     SliderPreference(
         title,
@@ -201,13 +201,13 @@ fun CheckBoxPreference(
     icon: ImageVector? = null,
     preference: PreferenceStore.Preference<Set<String>>
 ) {
-    var value by rememberPreferenceNull(preference)
+    var value by rememberPreference(preference)
 
     CheckBoxPreference(
         title,
         desc,
         descLong,
-        selectedValues = value?.map { v -> v.toInt() }?.toSet(),
+        selectedValues = value.map { v -> v.toInt() }.toSet(),
         valueStrings,
         icon,
         onReset = { value = preference.defaultValue }
@@ -257,7 +257,7 @@ fun TextBoxPreference(
     enabled: Boolean = true,
     preference: PreferenceStore.Preference<String>
 ) {
-    var value by rememberPreferenceNull(preference)
+    var value by rememberPreference(preference)
 
     TextBoxPreference(
         title,

--- a/app/src/main/java/dev/fabik/bluetoothhid/ui/ProfileManageDialog.kt
+++ b/app/src/main/java/dev/fabik/bluetoothhid/ui/ProfileManageDialog.kt
@@ -46,15 +46,15 @@ fun ProfileManageDialog(dialogState: DialogState) {
         .collectAsStateWithLifecycle(initialValue = setOf(ProfileManager.DEFAULT))
     val activeProfile by ProfileManager.activeProfile.collectAsStateWithLifecycle()
 
-    var showAddField by remember { mutableStateOf(false) }
-    var newProfileName by remember { mutableStateOf("") }
-    var nameError by remember { mutableStateOf<String?>(null) }
-
     val sortedProfiles = remember(profiles) {
         profiles.sortedWith(compareBy({ it != ProfileManager.DEFAULT }, { it }))
     }
 
     InfoDialog(dialogState, stringResource(R.string.manage_profiles)) {
+        var showAddField by remember { mutableStateOf(false) }
+        var newProfileName by remember { mutableStateOf("") }
+        var nameError by remember { mutableStateOf<String?>(null) }
+
         Column {
             LazyColumn(modifier = Modifier.fillMaxWidth()) {
                 items(sortedProfiles) { profile ->
@@ -68,13 +68,15 @@ fun ProfileManageDialog(dialogState: DialogState) {
                                     }
                                 }
                             }
+                            .height(56.dp)
                             .padding(vertical = 4.dp),
                         verticalAlignment = Alignment.CenterVertically,
                         horizontalArrangement = Arrangement.SpaceBetween
                     ) {
                         RadioButton(
                             selected = profile == activeProfile,
-                            onClick = null
+                            onClick = null,
+                            modifier = Modifier.padding(4.dp)
                         )
                         Text(
                             profile,

--- a/app/src/main/java/dev/fabik/bluetoothhid/ui/ProfileManageDialog.kt
+++ b/app/src/main/java/dev/fabik/bluetoothhid/ui/ProfileManageDialog.kt
@@ -125,8 +125,9 @@ fun ProfileManageDialog(dialogState: DialogState) {
                         IconButton(
                             enabled = nameError == null && newProfileName.isNotBlank(),
                             onClick = {
+                                val name = newProfileName.trim()
                                 scope.launch {
-                                    ProfileManager.createProfile(context, newProfileName.trim())
+                                    ProfileManager.createProfile(context, name)
                                 }
                                 newProfileName = ""
                                 showAddField = false

--- a/app/src/main/java/dev/fabik/bluetoothhid/ui/ProfileManageDialog.kt
+++ b/app/src/main/java/dev/fabik/bluetoothhid/ui/ProfileManageDialog.kt
@@ -1,0 +1,168 @@
+package dev.fabik.bluetoothhid.ui
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.RadioButton
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import dev.fabik.bluetoothhid.R
+import dev.fabik.bluetoothhid.utils.ProfileManager
+import kotlinx.coroutines.launch
+
+@Composable
+fun ProfileManageDialog(onDismiss: () -> Unit) {
+    val context = LocalContext.current
+    val scope = rememberCoroutineScope()
+
+    val profiles by remember { ProfileManager.getProfilesFlow(context) }
+        .collectAsStateWithLifecycle(initialValue = setOf(ProfileManager.DEFAULT))
+    val activeProfile by ProfileManager.activeProfile.collectAsStateWithLifecycle()
+
+    var showAddField by remember { mutableStateOf(false) }
+    var newProfileName by remember { mutableStateOf("") }
+    var nameError by remember { mutableStateOf<String?>(null) }
+
+    val sortedProfiles = remember(profiles) {
+        profiles.sortedWith(compareBy({ it != ProfileManager.DEFAULT }, { it }))
+    }
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(stringResource(R.string.manage_profiles)) },
+        text = {
+            Column {
+                LazyColumn(modifier = Modifier.fillMaxWidth()) {
+                    items(sortedProfiles) { profile ->
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .clickable {
+                                    if (profile != activeProfile) {
+                                        scope.launch {
+                                            ProfileManager.switchProfile(context, profile)
+                                        }
+                                    }
+                                }
+                                .padding(vertical = 4.dp),
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.SpaceBetween
+                        ) {
+                            Row(
+                                verticalAlignment = Alignment.CenterVertically,
+                                modifier = Modifier.weight(1f)
+                            ) {
+                                RadioButton(
+                                    selected = profile == activeProfile,
+                                    onClick = {
+                                        if (profile != activeProfile) {
+                                            scope.launch {
+                                                ProfileManager.switchProfile(context, profile)
+                                            }
+                                        }
+                                    }
+                                )
+                                Text(profile, style = MaterialTheme.typography.bodyMedium)
+                            }
+                            // Can't delete Default or active profile
+                            if (profile != ProfileManager.DEFAULT && profile != activeProfile) {
+                                IconButton(
+                                    onClick = {
+                                        scope.launch {
+                                            ProfileManager.deleteProfile(context, profile)
+                                        }
+                                    }
+                                ) {
+                                    Icon(
+                                        Icons.Default.Delete,
+                                        contentDescription = stringResource(R.string.delete_profile),
+                                        tint = MaterialTheme.colorScheme.error
+                                    )
+                                }
+                            }
+                        }
+                        HorizontalDivider()
+                    }
+                }
+
+                Spacer(Modifier.height(8.dp))
+
+                if (showAddField) {
+                    OutlinedTextField(
+                        value = newProfileName,
+                        onValueChange = {
+                            newProfileName = it
+                            nameError = null
+                        },
+                        label = { Text(stringResource(R.string.profile_name)) },
+                        isError = nameError != null,
+                        supportingText = nameError?.let { { Text(it) } },
+                        singleLine = true,
+                        modifier = Modifier.fillMaxWidth(),
+                        trailingIcon = {
+                            IconButton(onClick = {
+                                val trimmed = newProfileName.trim()
+                                when {
+                                    trimmed.isEmpty() ->
+                                        nameError = context.getString(R.string.profile_name_empty)
+                                    profiles.contains(trimmed) ->
+                                        nameError = context.getString(R.string.profile_name_exists)
+                                    else -> {
+                                        scope.launch {
+                                            ProfileManager.createProfile(context, trimmed)
+                                        }
+                                        newProfileName = ""
+                                        showAddField = false
+                                    }
+                                }
+                            }) {
+                                Icon(Icons.Default.Add, contentDescription = null)
+                            }
+                        }
+                    )
+                } else {
+                    TextButton(
+                        onClick = { showAddField = true },
+                        modifier = Modifier.fillMaxWidth()
+                    ) {
+                        Icon(Icons.Default.Add, contentDescription = null)
+                        Text(stringResource(R.string.add_profile))
+                    }
+                }
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = onDismiss) {
+                Text(stringResource(android.R.string.ok))
+            }
+        }
+    )
+}

--- a/app/src/main/java/dev/fabik/bluetoothhid/ui/ProfileManageDialog.kt
+++ b/app/src/main/java/dev/fabik/bluetoothhid/ui/ProfileManageDialog.kt
@@ -13,7 +13,6 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Delete
-import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -39,7 +38,7 @@ import dev.fabik.bluetoothhid.utils.ProfileManager
 import kotlinx.coroutines.launch
 
 @Composable
-fun ProfileManageDialog(onDismiss: () -> Unit) {
+fun ProfileManageDialog(dialogState: DialogState) {
     val context = LocalContext.current
     val scope = rememberCoroutineScope()
 
@@ -55,114 +54,97 @@ fun ProfileManageDialog(onDismiss: () -> Unit) {
         profiles.sortedWith(compareBy({ it != ProfileManager.DEFAULT }, { it }))
     }
 
-    AlertDialog(
-        onDismissRequest = onDismiss,
-        title = { Text(stringResource(R.string.manage_profiles)) },
-        text = {
-            Column {
-                LazyColumn(modifier = Modifier.fillMaxWidth()) {
-                    items(sortedProfiles) { profile ->
-                        Row(
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .clickable {
-                                    if (profile != activeProfile) {
-                                        scope.launch {
-                                            ProfileManager.switchProfile(context, profile)
-                                        }
+    InfoDialog(dialogState, stringResource(R.string.manage_profiles)) {
+        Column {
+            LazyColumn(modifier = Modifier.fillMaxWidth()) {
+                items(sortedProfiles) { profile ->
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .clickable {
+                                if (profile != activeProfile) {
+                                    scope.launch {
+                                        ProfileManager.switchProfile(context, profile)
                                     }
                                 }
-                                .padding(vertical = 4.dp),
-                            verticalAlignment = Alignment.CenterVertically,
-                            horizontalArrangement = Arrangement.SpaceBetween
-                        ) {
-                            Row(
-                                verticalAlignment = Alignment.CenterVertically,
-                                modifier = Modifier.weight(1f)
-                            ) {
-                                RadioButton(
-                                    selected = profile == activeProfile,
-                                    onClick = {
-                                        if (profile != activeProfile) {
-                                            scope.launch {
-                                                ProfileManager.switchProfile(context, profile)
-                                            }
-                                        }
-                                    }
-                                )
-                                Text(profile, style = MaterialTheme.typography.bodyMedium)
                             }
-                            // Can't delete Default or active profile
-                            if (profile != ProfileManager.DEFAULT && profile != activeProfile) {
-                                IconButton(
-                                    onClick = {
-                                        scope.launch {
-                                            ProfileManager.deleteProfile(context, profile)
-                                        }
-                                    }
-                                ) {
-                                    Icon(
-                                        Icons.Default.Delete,
-                                        contentDescription = stringResource(R.string.delete_profile),
-                                        tint = MaterialTheme.colorScheme.error
-                                    )
-                                }
-                            }
-                        }
-                        HorizontalDivider()
-                    }
-                }
-
-                Spacer(Modifier.height(8.dp))
-
-                if (showAddField) {
-                    OutlinedTextField(
-                        value = newProfileName,
-                        onValueChange = {
-                            newProfileName = it
-                            nameError = null
-                        },
-                        label = { Text(stringResource(R.string.profile_name)) },
-                        isError = nameError != null,
-                        supportingText = nameError?.let { { Text(it) } },
-                        singleLine = true,
-                        modifier = Modifier.fillMaxWidth(),
-                        trailingIcon = {
-                            IconButton(onClick = {
-                                val trimmed = newProfileName.trim()
-                                when {
-                                    trimmed.isEmpty() ->
-                                        nameError = context.getString(R.string.profile_name_empty)
-                                    profiles.contains(trimmed) ->
-                                        nameError = context.getString(R.string.profile_name_exists)
-                                    else -> {
-                                        scope.launch {
-                                            ProfileManager.createProfile(context, trimmed)
-                                        }
-                                        newProfileName = ""
-                                        showAddField = false
-                                    }
-                                }
-                            }) {
-                                Icon(Icons.Default.Add, contentDescription = null)
-                            }
-                        }
-                    )
-                } else {
-                    TextButton(
-                        onClick = { showAddField = true },
-                        modifier = Modifier.fillMaxWidth()
+                            .padding(vertical = 4.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.SpaceBetween
                     ) {
-                        Icon(Icons.Default.Add, contentDescription = null)
-                        Text(stringResource(R.string.add_profile))
+                        RadioButton(
+                            selected = profile == activeProfile,
+                            onClick = null
+                        )
+                        Text(
+                            profile,
+                            style = MaterialTheme.typography.bodyMedium,
+                            modifier = Modifier.weight(1f)
+                        )
+                        // Can't delete Default or active profile
+                        if (profile != ProfileManager.DEFAULT && profile != activeProfile) {
+                            IconButton(
+                                onClick = {
+                                    scope.launch {
+                                        ProfileManager.deleteProfile(context, profile)
+                                    }
+                                }
+                            ) {
+                                Icon(
+                                    Icons.Default.Delete,
+                                    contentDescription = stringResource(R.string.delete_profile),
+                                    tint = MaterialTheme.colorScheme.error
+                                )
+                            }
+                        }
                     }
+                    HorizontalDivider()
                 }
             }
-        },
-        confirmButton = {
-            TextButton(onClick = onDismiss) {
-                Text(stringResource(android.R.string.ok))
+
+            Spacer(Modifier.height(8.dp))
+
+            if (showAddField) {
+                OutlinedTextField(
+                    value = newProfileName,
+                    onValueChange = {
+                        newProfileName = it
+                        val trimmed = it.trim()
+                        nameError = when {
+                            trimmed.isEmpty() -> context.getString(R.string.profile_name_empty)
+                            profiles.contains(trimmed) -> context.getString(R.string.profile_name_exists)
+                            else -> null
+                        }
+                    },
+                    label = { Text(stringResource(R.string.profile_name)) },
+                    isError = nameError != null,
+                    supportingText = nameError?.let { { Text(it) } },
+                    singleLine = true,
+                    modifier = Modifier.fillMaxWidth(),
+                    trailingIcon = {
+                        IconButton(
+                            enabled = nameError == null && newProfileName.isNotBlank(),
+                            onClick = {
+                                scope.launch {
+                                    ProfileManager.createProfile(context, newProfileName.trim())
+                                }
+                                newProfileName = ""
+                                showAddField = false
+                            }
+                        ) {
+                            Icon(Icons.Default.Add, contentDescription = null)
+                        }
+                    }
+                )
+            } else {
+                TextButton(
+                    onClick = { showAddField = true },
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    Icon(Icons.Default.Add, contentDescription = null)
+                    Text(stringResource(R.string.add_profile))
+                }
             }
         }
-    )
+    }
 }

--- a/app/src/main/java/dev/fabik/bluetoothhid/ui/model/CameraViewModel.kt
+++ b/app/src/main/java/dev/fabik/bluetoothhid/ui/model/CameraViewModel.kt
@@ -446,17 +446,20 @@ class CameraViewModel : ViewModel() {
 
     // Called when the user manually selects a barcode from the multi-code picker.
     fun selectBarcode(barcode: Barcode) {
-        _currentBarcode.update { barcode }
-        processAndDispatch(barcode, sourceImage = null)
+        processAndDispatch(barcode, sourceImage = null, resetDedup = true)
     }
 
     // Applies regex extraction and JS mapping, then calls onBarcodeDetected.
     // useRunBlocking=true is needed on the analyzer thread (auto-send) to preserve frame ordering.
+    // resetDedup=true clears lastBarcode so the same value can be re-sent (used by selectBarcode and auto-send).
     private fun processAndDispatch(
         barcode: Barcode,
         sourceImage: ImageProxy?,
-        useRunBlocking: Boolean = false
+        useRunBlocking: Boolean = false,
+        resetDedup: Boolean = false
     ) {
+        if (resetDedup) lastBarcode = null
+        _currentBarcode.update { barcode }
         val rawValue = barcode.value ?: return
         var value = rawValue
 
@@ -569,9 +572,7 @@ class CameraViewModel : ViewModel() {
             newBarcodes.forEach { barcode ->
                 if (barcode.value != null) {
                     sentInSession.add(barcode.value!!)
-                    _currentBarcode.update { barcode }
-                    lastBarcode = null  // reset dedup so onBarcodeDetected accepts each new code
-                    processAndDispatch(barcode, sourceImage, useRunBlocking = true)
+                    processAndDispatch(barcode, sourceImage, useRunBlocking = true, resetDedup = true)
                 }
             }
         } else if (multiCodeDetection) {
@@ -584,10 +585,10 @@ class CameraViewModel : ViewModel() {
         } else {
             // Single-code mode: existing behaviour, take first match
             val barcode = allBarcodes.firstOrNull()
-            _currentBarcode.update { barcode }
-
             if (barcode != null) {
                 processAndDispatch(barcode, sourceImage)
+            } else {
+                _currentBarcode.update { null }
             }
         }
     }

--- a/app/src/main/java/dev/fabik/bluetoothhid/ui/model/CameraViewModel.kt
+++ b/app/src/main/java/dev/fabik/bluetoothhid/ui/model/CameraViewModel.kt
@@ -37,7 +37,6 @@ import androidx.camera.core.resolutionselector.ResolutionStrategy
 import androidx.camera.lifecycle.ProcessCameraProvider
 import androidx.camera.lifecycle.awaitInstance
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.geometry.Offset
@@ -56,6 +55,8 @@ import dev.fabik.bluetoothhid.utils.FocusMode
 import dev.fabik.bluetoothhid.utils.JsEngineService
 import dev.fabik.bluetoothhid.utils.LatencyTrace
 import dev.fabik.bluetoothhid.utils.ScanAreaData
+import dev.fabik.bluetoothhid.utils.ScanAreaData.Companion.toOverlayOffset
+import dev.fabik.bluetoothhid.utils.ScanAreaData.Companion.toOverlaySize
 import dev.fabik.bluetoothhid.utils.ScanFrequency
 import dev.fabik.bluetoothhid.utils.ScanImageFormat
 import dev.fabik.bluetoothhid.utils.ScanResolution
@@ -113,7 +114,8 @@ class CameraViewModel : ViewModel() {
     var scanRect = Rect.Zero
     // For CUSTOM overlay with multiple areas: individual rects for filtering, empty = use scanRect
     var scanRects: List<Rect> = emptyList()
-    val areas = mutableStateListOf<ScanAreaData>()
+    private val _areas = MutableStateFlow<List<ScanAreaData>>(emptyList())
+    val areas = _areas.asStateFlow()
     var overlayPosition by mutableStateOf<Offset?>(null)
     var overlaySize by mutableStateOf<androidx.compose.ui.geometry.Size?>(null)
 
@@ -340,7 +342,7 @@ class CameraViewModel : ViewModel() {
         }
     }
 
-    var viewSize: IntSize? = null
+    var viewSize by mutableStateOf<IntSize?>(null)
     var lastScanSize: Size? = null
     private var scale = 1.0f
     private var translation = Offset(0.0f, 0.0f)
@@ -475,7 +477,6 @@ class CameraViewModel : ViewModel() {
     private fun processAndDispatch(
         barcode: Barcode,
         sourceImage: ImageProxy?,
-        useRunBlocking: Boolean = false,
         resetDedup: Boolean = false
     ) {
         if (resetDedup) lastBarcode = null
@@ -491,18 +492,13 @@ class CameraViewModel : ViewModel() {
         } ?: emptyList()
 
         _jsEngineService?.let { s ->
-            if (useRunBlocking) {
-                runBlocking {
-                    value = mapJS(s, value, ZXingAnalyzer.format2String(barcode.format))
-                    onBarcodeDetected(value, barcode.format, sourceImage, regexGroups)
-                }
-            } else {
-                viewModelScope.launch {
-                    value = mapJS(s, value, ZXingAnalyzer.format2String(barcode.format))
-                    onBarcodeDetected(value, barcode.format, sourceImage, regexGroups)
-                }
+            // This must be blocking otherwise the image might already be closed
+            // when trying to save it later in onBarcodeDetected
+            value = runBlocking {
+                mapJS(s, value, ZXingAnalyzer.format2String(barcode.format))
             }
-        } ?: onBarcodeDetected(value, barcode.format, sourceImage, regexGroups)
+        }
+        onBarcodeDetected(value, barcode.format, sourceImage, regexGroups)
     }
 
     var lastDetectionTime: Long? = null
@@ -606,7 +602,11 @@ class CameraViewModel : ViewModel() {
             newBarcodes.forEach { barcode ->
                 if (barcode.value != null) {
                     sentInSession.add(barcode.value!!)
-                    processAndDispatch(barcode, sourceImage, useRunBlocking = true, resetDedup = true)
+                    processAndDispatch(
+                        barcode,
+                        sourceImage,
+                        resetDedup = true
+                    )
                 }
             }
         } else if (multiCodeDetection) {
@@ -876,4 +876,40 @@ class CameraViewModel : ViewModel() {
 
     fun Offset.toPoint() = Point(x.toInt(), y.toInt())
 
+    fun clearScanAreas() {
+        _areas.update { emptyList() }
+    }
+
+    fun addScanAreas(vararg area: ScanAreaData) {
+        _areas.update { it + area }
+        // Keep legacy fields in sync with first area for debug overlay
+        if (areas.value.isNotEmpty()) {
+            overlayPosition = areas.value.first().toOverlayOffset()
+            overlaySize = areas.value.first().toOverlaySize()
+        }
+    }
+
+    fun updateScanArea(index: Int, area: ScanAreaData) {
+        if (index >= areas.value.size) return
+        _areas.update {
+            it.toMutableList().also { l -> l[index] = area }
+        }
+        // Keep legacy fields in sync with first area for debug overlay
+        if (index == 0) {
+            overlayPosition = areas.value.first().toOverlayOffset()
+            overlaySize = areas.value.first().toOverlaySize()
+        }
+    }
+
+    fun removeScanArea(index: Int) {
+        if (index >= areas.value.size) return
+        _areas.update {
+            it.toMutableList().also { l -> l.removeAt(index) }
+        }
+        // Keep legacy fields in sync with first area for debug overlay
+        if (areas.value.isNotEmpty()) {
+            overlayPosition = areas.value.first().toOverlayOffset()
+            overlaySize = areas.value.first().toOverlaySize()
+        }
+    }
 }

--- a/app/src/main/java/dev/fabik/bluetoothhid/ui/model/CameraViewModel.kt
+++ b/app/src/main/java/dev/fabik/bluetoothhid/ui/model/CameraViewModel.kt
@@ -54,6 +54,7 @@ import dev.fabik.bluetoothhid.utils.CropMode
 import dev.fabik.bluetoothhid.utils.FocusMode
 import dev.fabik.bluetoothhid.utils.JsEngineService
 import dev.fabik.bluetoothhid.utils.LatencyTrace
+import dev.fabik.bluetoothhid.utils.ScanAreaData
 import dev.fabik.bluetoothhid.utils.ScanFrequency
 import dev.fabik.bluetoothhid.utils.ScanImageFormat
 import dev.fabik.bluetoothhid.utils.ScanResolution
@@ -110,6 +111,9 @@ class CameraViewModel : ViewModel() {
         { _, _, _, _ -> }
 
     var scanRect = Rect.Zero
+    // For CUSTOM overlay with multiple areas: individual rects for filtering, empty = use scanRect
+    var scanRects: List<Rect> = emptyList()
+    var scanAreas by mutableStateOf<List<ScanAreaData>>(emptyList())
     var overlayPosition by mutableStateOf<Offset?>(null)
     var overlaySize by mutableStateOf<androidx.compose.ui.geometry.Size?>(null)
 
@@ -404,7 +408,9 @@ class CameraViewModel : ViewModel() {
         scanSaveQuality: Int,
         saveScanFileName: String,
         clearAfterTime: Long?,
-        saveScanImageFormat: ScanImageFormat
+        saveScanImageFormat: ScanImageFormat,
+        multiCodeDetection: Boolean = false,
+        autoSend: Boolean = false
     ) {
         _scanDelay = frequency.delayMs
         barcodeAnalyzer?.scanDelay = _scanDelay
@@ -431,14 +437,50 @@ class CameraViewModel : ViewModel() {
         _saveScanImageFormat = saveScanImageFormat
 
         _clearAfterTime = clearAfterTime
+        this.multiCodeDetection = multiCodeDetection
+        _autoSend = autoSend
 
         Log.d(TAG, "Updated scan parameters")
+    }
+
+    // Called when the user manually selects a barcode from the multi-code picker.
+    // Runs through JS/regex processing and triggers onBarcodeDetected.
+    fun selectBarcode(barcode: Barcode) {
+        val rawValue = barcode.value ?: return
+        lastBarcode = null  // Bypass dedup so repeated taps on the same code work
+        _currentBarcode.update { barcode }
+
+        var value = rawValue
+        val regexGroups: List<String> = _scanRegex?.let { re ->
+            re.find(value)?.let { match ->
+                match.groupValues.getOrNull(1)?.let { group -> value = group }
+                match.groupValues.drop(1)
+            } ?: emptyList()
+        } ?: emptyList()
+
+        _jsEngineService?.let { s ->
+            viewModelScope.launch {
+                value = mapJS(s, value, ZXingAnalyzer.format2String(barcode.format))
+                onBarcodeDetected(value, barcode.format, null, regexGroups)
+            }
+        } ?: onBarcodeDetected(value, barcode.format, null, regexGroups)
     }
 
     var lastDetectionTime: Long? = null
     var lastBarcode: String? = null
     private val _currentBarcode = MutableStateFlow<Barcode?>(null)
     val currentBarcode: StateFlow<Barcode?> = _currentBarcode.asStateFlow()
+
+    // All barcodes detected in the current frame (multi-code mode visual)
+    private val _detectedBarcodes = MutableStateFlow<List<Barcode>>(emptyList())
+    val detectedBarcodes: StateFlow<List<Barcode>> = _detectedBarcodes.asStateFlow()
+
+    // Tracks which barcodes have already been queued in the current "scene"
+    // Cleared when the frame contains no barcodes (camera moved away)
+    private val sentInSession = mutableSetOf<String>()
+
+    var multiCodeDetection: Boolean = false
+    private var _autoSend: Boolean = false
 
     data class Barcode(
         var value: String?,
@@ -453,7 +495,7 @@ class CameraViewModel : ViewModel() {
     ) {
         detectorTrace.trigger()
 
-        val barcode = result.map {
+        val allBarcodes = result.map {
             val cornerPoints = listOf(
                 it.position.topLeft,
                 it.position.topRight,
@@ -476,41 +518,98 @@ class CameraViewModel : ViewModel() {
 
             Barcode(it.text, cornerPoints, it.format)
         }.filter {
-            when (_fullyInside) {
-                true -> true    // Automatically handled with setting cropRect
-                false -> it.cornerPoints.any { scanRect.contains(Offset(it.x, it.y)) }
+            if (scanRects.size > 1) {
+                // Multi-area: check each individual rect
+                if (_fullyInside)
+                    scanRects.any { r -> it.cornerPoints.all { p -> r.contains(Offset(p.x, p.y)) } }
+                else
+                    it.cornerPoints.any { p -> scanRects.any { r -> r.contains(Offset(p.x, p.y)) } }
+            } else {
+                when (_fullyInside) {
+                    true -> true    // Automatically handled with setting cropRect
+                    false -> it.cornerPoints.any { scanRect.contains(Offset(it.x, it.y)) }
+                }
             }
         }.filter {
             _scanRegex?.matches(it.value ?: return@filter true) != false
-        }.firstOrNull()
+        }
 
-        _currentBarcode.update { _ -> barcode }
+        // Always expose all detected barcodes for visual overlay and picker
+        _detectedBarcodes.update { allBarcodes }
 
-        barcode?.value?.let { v ->
-            var value = v
+        if (_autoSend) {
+            // Auto-send: queue all new barcodes in this frame (dedup within session)
+            if (allBarcodes.isEmpty()) {
+                sentInSession.clear()
+                if (lastBarcode != null) {
+                    _currentBarcode.update { null }
+                    onBarcodeDetected(null, BarcodeReader.Format.NONE, null, emptyList())
+                    lastBarcode = null
+                }
+                return
+            }
 
-            // Compute regex capture groups locally — passed directly through the callback chain
-            // instead of being stored as ViewModel state, to avoid threading issues.
-            val regexGroups: List<String> = _scanRegex?.let { re ->
-                re.find(value)?.let { match ->
-                    // Use first capture group as the main value (backward compat)
-                    match.groupValues.getOrNull(1)?.let { group ->
-                        value = group
-                    }
-                    // Return all capture groups (1..N) for {CODE%N} template support
-                    match.groupValues.drop(1)
+            val newBarcodes = allBarcodes.filter { !sentInSession.contains(it.value) }
+            newBarcodes.forEach { barcode ->
+                barcode.value?.let { v ->
+                    sentInSession.add(v)
+                    _currentBarcode.update { barcode }
+
+                    var value = v
+                    val regexGroups: List<String> = _scanRegex?.let { re ->
+                        re.find(value)?.let { match ->
+                            match.groupValues.getOrNull(1)?.let { group -> value = group }
+                            match.groupValues.drop(1)
+                        } ?: emptyList()
+                    } ?: emptyList()
+
+                    // Reset lastBarcode so onBarcodeDetected's dedup doesn't block this code
+                    lastBarcode = null
+                    _jsEngineService?.let { s ->
+                        runBlocking {
+                            value = mapJS(s, value, ZXingAnalyzer.format2String(barcode.format))
+                            onBarcodeDetected(value, barcode.format, sourceImage, regexGroups)
+                        }
+                    } ?: onBarcodeDetected(value, barcode.format, sourceImage, regexGroups)
+                }
+            }
+        } else if (multiCodeDetection) {
+            // Manual multi-code: barcodes are exposed via _detectedBarcodes for the picker UI.
+            // No auto-send — user selects from the picker. Clear session when frame is empty.
+            if (allBarcodes.isEmpty()) {
+                sentInSession.clear()
+                _currentBarcode.update { null }
+            }
+        } else {
+            // Single-code mode: existing behaviour, take first match
+            val barcode = allBarcodes.firstOrNull()
+            _currentBarcode.update { barcode }
+
+            barcode?.value?.let { v ->
+                var value = v
+
+                // Compute regex capture groups locally — passed directly through the callback chain
+                // instead of being stored as ViewModel state, to avoid threading issues.
+                val regexGroups: List<String> = _scanRegex?.let { re ->
+                    re.find(value)?.let { match ->
+                        // Use first capture group as the main value (backward compat)
+                        match.groupValues.getOrNull(1)?.let { group ->
+                            value = group
+                        }
+                        // Return all capture groups (1..N) for {CODE%N} template support
+                        match.groupValues.drop(1)
+                    } ?: emptyList()
                 } ?: emptyList()
-            } ?: emptyList()
 
-            _jsEngineService?.let { s ->
-                // Only blocks the analyzer thread
-                runBlocking {
-                    value =
-                        mapJS(s, value, ZXingAnalyzer.format2String(barcode.format))
+                _jsEngineService?.let { s ->
+                    // Only blocks the analyzer thread
+                    runBlocking {
+                        value = mapJS(s, value, ZXingAnalyzer.format2String(barcode.format))
+                        onBarcodeDetected(value, barcode.format, sourceImage, regexGroups)
+                    }
+                } ?: run {
                     onBarcodeDetected(value, barcode.format, sourceImage, regexGroups)
                 }
-            } ?: run {
-                onBarcodeDetected(value, barcode.format, sourceImage, regexGroups)
             }
         }
     }
@@ -538,7 +637,12 @@ class CameraViewModel : ViewModel() {
                         Offset(point.x, point.y)
                     }
 
-                    return@filter when (_fullyInside) {
+                    return@filter if (scanRects.size > 1) {
+                        if (_fullyInside)
+                            scanRects.any { r -> cornerPoints.all { p -> r.contains(p) } }
+                        else
+                            scanRects.any { r -> r.overlaps(Rect(cornerPoints[0], cornerPoints[2])) }
+                    } else when (_fullyInside) {
                         false -> scanRect.overlaps(Rect(cornerPoints[0], cornerPoints[2]))
                         true -> cornerPoints.all { scanRect.contains(it) }
                     }

--- a/app/src/main/java/dev/fabik/bluetoothhid/ui/model/CameraViewModel.kt
+++ b/app/src/main/java/dev/fabik/bluetoothhid/ui/model/CameraViewModel.kt
@@ -37,6 +37,7 @@ import androidx.camera.core.resolutionselector.ResolutionStrategy
 import androidx.camera.lifecycle.ProcessCameraProvider
 import androidx.camera.lifecycle.awaitInstance
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.geometry.Offset
@@ -113,7 +114,7 @@ class CameraViewModel : ViewModel() {
     var scanRect = Rect.Zero
     // For CUSTOM overlay with multiple areas: individual rects for filtering, empty = use scanRect
     var scanRects: List<Rect> = emptyList()
-    var scanAreas by mutableStateOf<List<ScanAreaData>>(emptyList())
+    val areas = mutableStateListOf<ScanAreaData>()
     var overlayPosition by mutableStateOf<Offset?>(null)
     var overlaySize by mutableStateOf<androidx.compose.ui.geometry.Size?>(null)
 

--- a/app/src/main/java/dev/fabik/bluetoothhid/ui/model/CameraViewModel.kt
+++ b/app/src/main/java/dev/fabik/bluetoothhid/ui/model/CameraViewModel.kt
@@ -444,13 +444,21 @@ class CameraViewModel : ViewModel() {
     }
 
     // Called when the user manually selects a barcode from the multi-code picker.
-    // Runs through JS/regex processing and triggers onBarcodeDetected.
     fun selectBarcode(barcode: Barcode) {
-        val rawValue = barcode.value ?: return
-        lastBarcode = null  // Bypass dedup so repeated taps on the same code work
         _currentBarcode.update { barcode }
+        processAndDispatch(barcode, sourceImage = null)
+    }
 
+    // Applies regex extraction and JS mapping, then calls onBarcodeDetected.
+    // useRunBlocking=true is needed on the analyzer thread (auto-send) to preserve frame ordering.
+    private fun processAndDispatch(
+        barcode: Barcode,
+        sourceImage: ImageProxy?,
+        useRunBlocking: Boolean = false
+    ) {
+        val rawValue = barcode.value ?: return
         var value = rawValue
+
         val regexGroups: List<String> = _scanRegex?.let { re ->
             re.find(value)?.let { match ->
                 match.groupValues.getOrNull(1)?.let { group -> value = group }
@@ -459,11 +467,18 @@ class CameraViewModel : ViewModel() {
         } ?: emptyList()
 
         _jsEngineService?.let { s ->
-            viewModelScope.launch {
-                value = mapJS(s, value, ZXingAnalyzer.format2String(barcode.format))
-                onBarcodeDetected(value, barcode.format, null, regexGroups)
+            if (useRunBlocking) {
+                runBlocking {
+                    value = mapJS(s, value, ZXingAnalyzer.format2String(barcode.format))
+                    onBarcodeDetected(value, barcode.format, sourceImage, regexGroups)
+                }
+            } else {
+                viewModelScope.launch {
+                    value = mapJS(s, value, ZXingAnalyzer.format2String(barcode.format))
+                    onBarcodeDetected(value, barcode.format, sourceImage, regexGroups)
+                }
             }
-        } ?: onBarcodeDetected(value, barcode.format, null, regexGroups)
+        } ?: onBarcodeDetected(value, barcode.format, sourceImage, regexGroups)
     }
 
     var lastDetectionTime: Long? = null
@@ -551,26 +566,11 @@ class CameraViewModel : ViewModel() {
 
             val newBarcodes = allBarcodes.filter { !sentInSession.contains(it.value) }
             newBarcodes.forEach { barcode ->
-                barcode.value?.let { v ->
-                    sentInSession.add(v)
+                if (barcode.value != null) {
+                    sentInSession.add(barcode.value!!)
                     _currentBarcode.update { barcode }
-
-                    var value = v
-                    val regexGroups: List<String> = _scanRegex?.let { re ->
-                        re.find(value)?.let { match ->
-                            match.groupValues.getOrNull(1)?.let { group -> value = group }
-                            match.groupValues.drop(1)
-                        } ?: emptyList()
-                    } ?: emptyList()
-
-                    // Reset lastBarcode so onBarcodeDetected's dedup doesn't block this code
-                    lastBarcode = null
-                    _jsEngineService?.let { s ->
-                        runBlocking {
-                            value = mapJS(s, value, ZXingAnalyzer.format2String(barcode.format))
-                            onBarcodeDetected(value, barcode.format, sourceImage, regexGroups)
-                        }
-                    } ?: onBarcodeDetected(value, barcode.format, sourceImage, regexGroups)
+                    lastBarcode = null  // reset dedup so onBarcodeDetected accepts each new code
+                    processAndDispatch(barcode, sourceImage, useRunBlocking = true)
                 }
             }
         } else if (multiCodeDetection) {
@@ -585,31 +585,8 @@ class CameraViewModel : ViewModel() {
             val barcode = allBarcodes.firstOrNull()
             _currentBarcode.update { barcode }
 
-            barcode?.value?.let { v ->
-                var value = v
-
-                // Compute regex capture groups locally — passed directly through the callback chain
-                // instead of being stored as ViewModel state, to avoid threading issues.
-                val regexGroups: List<String> = _scanRegex?.let { re ->
-                    re.find(value)?.let { match ->
-                        // Use first capture group as the main value (backward compat)
-                        match.groupValues.getOrNull(1)?.let { group ->
-                            value = group
-                        }
-                        // Return all capture groups (1..N) for {CODE%N} template support
-                        match.groupValues.drop(1)
-                    } ?: emptyList()
-                } ?: emptyList()
-
-                _jsEngineService?.let { s ->
-                    // Only blocks the analyzer thread
-                    runBlocking {
-                        value = mapJS(s, value, ZXingAnalyzer.format2String(barcode.format))
-                        onBarcodeDetected(value, barcode.format, sourceImage, regexGroups)
-                    }
-                } ?: run {
-                    onBarcodeDetected(value, barcode.format, sourceImage, regexGroups)
-                }
+            if (barcode != null) {
+                processAndDispatch(barcode, sourceImage)
             }
         }
     }

--- a/app/src/main/java/dev/fabik/bluetoothhid/utils/PreferenceStore.kt
+++ b/app/src/main/java/dev/fabik/bluetoothhid/utils/PreferenceStore.kt
@@ -14,6 +14,8 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
@@ -23,7 +25,6 @@ import androidx.datastore.preferences.core.intPreferencesKey
 import androidx.datastore.preferences.core.preferencesOf
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.core.stringSetPreferencesKey
-import androidx.datastore.preferences.preferencesDataStore
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import dev.fabik.bluetoothhid.BuildConfig
 import kotlinx.coroutines.Dispatchers
@@ -37,7 +38,13 @@ import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
 import org.json.JSONObject
 
-val Context.dataStore by preferencesDataStore("settings")
+// Active profile's DataStore — routes through ProfileManager so profile switches are reflected
+val Context.dataStore: DataStore<Preferences> get() = ProfileManager.currentStore(this)
+
+// CompositionLocal for reactive profile-aware DataStore access in composables
+val LocalDataStore = staticCompositionLocalOf<DataStore<Preferences>> {
+    error("LocalDataStore not provided — wrap your composable tree with CompositionLocalProvider(LocalDataStore provides ...)")
+}
 
 // Enums for type-safe preference values
 // Note: ordinal is used as index - no need for explicit val index
@@ -259,6 +266,7 @@ open class PreferenceStore {
         val FULL_INSIDE = booleanPreferencesKey("full_inside") defaultsTo true
         val OVERLAY_TYPE = intPreferencesKey("overlay_type").enumDefaultsTo(OverlayType::fromIndex)
         val AUTO_SEND = booleanPreferencesKey("auto_send") defaultsTo false
+        val MULTI_CODE_DETECTION = booleanPreferencesKey("multi_code_detection") defaultsTo false
         val PLAY_SOUND = booleanPreferencesKey("play_sound") defaultsTo false
         val VIBRATE = booleanPreferencesKey("vibrate") defaultsTo false
         val AUTO_COPY_TO_CLIPBOARD = booleanPreferencesKey("auto_copy_to_clipboard") defaultsTo false
@@ -302,6 +310,7 @@ open class PreferenceStore {
         val OVERLAY_POS_Y = floatPreferencesKey("overlay_pos_y") defaultsTo 0.0f
         val OVERLAY_WIDTH = floatPreferencesKey("overlay_width") defaultsTo 100.0f
         val OVERLAY_HEIGHT = floatPreferencesKey("overlay_height") defaultsTo 100.0f
+        val SCAN_AREAS = stringPreferencesKey("scan_areas") defaultsTo ""
         val FAVOURITE_DEVICES = stringSetPreferencesKey("favourite_devices") defaultsTo setOf()
     }
 }
@@ -385,8 +394,16 @@ fun Context.getPreferences(vararg prefs: PreferenceStore.Preference<*>): Flow<Ma
 
 @Composable
 fun Context.getMultiPreferenceState(vararg prefs: PreferenceStore.Preference<*>): State<Map<PreferenceStore.Preference<*>, *>?> {
-    // Use prefs array as key to ensure stable flow across recompositions
-    return remember(*prefs) { getPreferences(*prefs) }.collectAsStateWithLifecycle(null)
+    val dataStore = LocalDataStore.current
+    return remember(*prefs, dataStore) {
+        dataStore.data
+            .catch { e ->
+                Log.e("PreferenceStore", "Error reading preferences", e)
+                emit(emptyPreferences())
+            }
+            .map { preferences -> prefs.associateWith { pref -> preferences[pref.key] ?: pref.defaultValue } }
+            .flowOn(Dispatchers.IO)
+    }.collectAsStateWithLifecycle(null)
 }
 
 @Composable
@@ -394,23 +411,47 @@ fun <T> Context.getPreferenceStateDefault(
     pref: PreferenceStore.Preference<T>,
     initial: T = pref.defaultValue
 ): State<T> {
-    // Use pref.key to ensure stable flow across recompositions
-    val flow = remember(pref.key) { getPreference(pref) }
+    val dataStore = LocalDataStore.current
+    val flow = remember(pref.key, dataStore) {
+        dataStore.data
+            .catch { e ->
+                Log.e("PreferenceStore", "Error reading preference", e)
+                emit(preferencesOf(pref.key to pref.defaultValue))
+            }
+            .map { it[pref.key] ?: pref.defaultValue }
+            .flowOn(Dispatchers.IO)
+    }
     return flow.collectAsState(initial)
 }
 
 @Composable
 fun <T> Context.getPreferenceState(pref: PreferenceStore.Preference<T>): State<T?> {
-    // Use pref.key to ensure stable flow across recompositions
-    val flow = remember(pref.key) { getPreference(pref) }
+    val dataStore = LocalDataStore.current
+    val flow = remember(pref.key, dataStore) {
+        dataStore.data
+            .catch { e ->
+                Log.e("PreferenceStore", "Error reading preference", e)
+                emit(preferencesOf(pref.key to pref.defaultValue))
+            }
+            .map { it[pref.key] }
+            .flowOn(Dispatchers.IO)
+    }
     return flow.collectAsState(null)
 }
 
 @Composable
 fun <T> Context.getPreferenceStateBlocking(pref: PreferenceStore.Preference<T>): State<T> {
-    // Use pref.key to ensure stable flow and initial value across recompositions
-    val flow = remember(pref.key) { getPreference(pref) }
-    val initial = remember(pref.key) { runBlocking { flow.first() } }
+    val dataStore = LocalDataStore.current
+    val flow = remember(pref.key, dataStore) {
+        dataStore.data
+            .catch { e ->
+                Log.e("PreferenceStore", "Error reading preference", e)
+                emit(preferencesOf(pref.key to pref.defaultValue))
+            }
+            .map { it[pref.key] ?: pref.defaultValue }
+            .flowOn(Dispatchers.IO)
+    }
+    val initial = remember(pref.key, dataStore) { runBlocking { flow.first() } }
     return flow.collectAsState(initial)
 }
 
@@ -419,11 +460,11 @@ fun <T> rememberPreference(
     pref: PreferenceStore.Preference<T>,
 ): MutableState<T> {
     val context = LocalContext.current
+    val dataStore = LocalDataStore.current
     val scope = rememberCoroutineScope()
     val state = context.getPreferenceStateBlocking(pref)
 
-    // Use pref.key as remember key to ensure stable MutableState instance
-    return remember(pref.key) {
+    return remember(pref.key, dataStore) {
         object : MutableState<T> {
             override var value: T
                 get() = state.value
@@ -444,11 +485,11 @@ fun <T> rememberPreferenceNull(
     pref: PreferenceStore.Preference<T>,
 ): MutableState<T?> {
     val context = LocalContext.current
+    val dataStore = LocalDataStore.current
     val scope = rememberCoroutineScope()
     val state = context.getPreferenceState(pref)
 
-    // Use pref.key as remember key to ensure stable MutableState instance
-    return remember(pref.key) {
+    return remember(pref.key, dataStore) {
         object : MutableState<T?> {
             override var value: T?
                 get() = state.value
@@ -469,12 +510,13 @@ fun <E : Enum<E>> rememberEnumPreference(
     pref: PreferenceStore.EnumPref<E>,
 ): MutableState<E> {
     val context = LocalContext.current
+    val dataStore = LocalDataStore.current
     val scope = rememberCoroutineScope()
     val intState = context.getPreferenceStateBlocking(pref)
 
-    // Use pref.key as remember key to ensure stable MutableState instance
-    // Using intState.value would recreate the object on every value change (race condition bug)
-    return remember(pref.key) {
+    // dataStore added as key so the object is recreated when profile switches,
+    // picking up the new intState from the new store
+    return remember(pref.key, dataStore) {
         object : MutableState<E> {
             override var value: E
                 get() = pref.fromOrdinal(intState.value)

--- a/app/src/main/java/dev/fabik/bluetoothhid/utils/ProfileManager.kt
+++ b/app/src/main/java/dev/fabik/bluetoothhid/utils/ProfileManager.kt
@@ -114,7 +114,6 @@ object ProfileManager {
         storeCache.remove(id)
         val appContext = context.applicationContext
         val fileName = "settings_$id"
-        appContext.filesDir.resolve("datastore/$fileName.preferences_pb").delete()
-        appContext.filesDir.resolve("datastore/$fileName.preferences_pb.tmp").delete()
+        appContext.preferencesDataStoreFile(fileName).delete()
     }
 }

--- a/app/src/main/java/dev/fabik/bluetoothhid/utils/ProfileManager.kt
+++ b/app/src/main/java/dev/fabik/bluetoothhid/utils/ProfileManager.kt
@@ -3,65 +3,90 @@ package dev.fabik.bluetoothhid.utils
 import android.content.Context
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.stringPreferencesKey
-import androidx.datastore.preferences.core.stringSetPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
-import androidx.datastore.preferences.core.PreferenceDataStoreFactory
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
+import org.json.JSONObject
+import java.util.UUID
+import java.util.concurrent.ConcurrentHashMap
 
 // Separate store for profile metadata — never part of any profile's settings
 private val Context.globalDataStore: DataStore<Preferences> by preferencesDataStore("global")
 
 object ProfileManager {
     const val DEFAULT = "Default"
-    private val ACTIVE_KEY = stringPreferencesKey("active_profile")
-    private val NAMES_KEY = stringSetPreferencesKey("profile_names")
+    private const val DEFAULT_ID = "default"
 
-    private val storeCache = HashMap<String, DataStore<Preferences>>()
+    private val ACTIVE_KEY = stringPreferencesKey("active_profile")
+    // JSON object: { displayName: fileId, ... }  e.g. {"Default":"default","Work":"550e8400-..."}
+    private val PROFILES_KEY = stringPreferencesKey("profiles_map")
+
+    // Keyed by file ID (UUID or "default"), not by display name — avoids collisions
+    private val storeCache = ConcurrentHashMap<String, DataStore<Preferences>>()
+    // In-memory map: displayName → fileId, populated in initialize()
+    private val profileMap = ConcurrentHashMap<String, String>()
 
     private val _activeProfile = MutableStateFlow(DEFAULT)
     val activeProfile: StateFlow<String> = _activeProfile.asStateFlow()
 
-    private fun sanitize(name: String) = name.lowercase().replace(Regex("[^a-z0-9_]"), "_")
+    private fun parseProfileMap(json: String): Map<String, String> =
+        runCatching {
+            val obj = JSONObject(json)
+            obj.keys().asSequence().associateWith { obj.getString(it) }
+        }.getOrDefault(mapOf(DEFAULT to DEFAULT_ID))
+
+    private fun serializeProfileMap(map: Map<String, String>): String =
+        JSONObject(map).toString()
 
     @Synchronized
-    fun getOrCreateStore(context: Context, profileName: String): DataStore<Preferences> {
-        return storeCache.getOrPut(profileName) {
+    private fun getOrCreateStoreById(context: Context, fileId: String): DataStore<Preferences> {
+        return storeCache.getOrPut(fileId) {
             val appContext = context.applicationContext
-            // Default profile reuses the existing settings.preferences_pb file (backward compat)
-            val fileName = if (profileName == DEFAULT) "settings" else "settings_${sanitize(profileName)}"
+            // Default profile reuses the existing settings.preferences_pb (backward compat)
+            val fileName = if (fileId == DEFAULT_ID) "settings" else "settings_$fileId"
             PreferenceDataStoreFactory.create {
                 appContext.filesDir.resolve("datastore/$fileName.preferences_pb")
             }
         }
     }
 
-    fun currentStore(context: Context): DataStore<Preferences> =
-        getOrCreateStore(context, _activeProfile.value)
+    fun currentStore(context: Context): DataStore<Preferences> {
+        val id = profileMap[_activeProfile.value] ?: DEFAULT_ID
+        return getOrCreateStoreById(context, id)
+    }
 
     fun activeStoreFlow(context: Context): Flow<DataStore<Preferences>> =
-        _activeProfile.map { getOrCreateStore(context, it) }
+        _activeProfile.map { name ->
+            val id = profileMap[name] ?: DEFAULT_ID
+            getOrCreateStoreById(context, id)
+        }
 
     suspend fun initialize(context: Context) {
         val appContext = context.applicationContext
         val prefs = appContext.globalDataStore.data.first()
-        val savedProfile = prefs[ACTIVE_KEY] ?: DEFAULT
-        // Ensure the profiles list always contains at least Default
-        if (prefs[NAMES_KEY] == null) {
-            appContext.globalDataStore.edit { it[NAMES_KEY] = setOf(DEFAULT) }
+
+        val map = prefs[PROFILES_KEY]?.let { parseProfileMap(it) } ?: run {
+            val defaultMap = mapOf(DEFAULT to DEFAULT_ID)
+            appContext.globalDataStore.edit { it[PROFILES_KEY] = serializeProfileMap(defaultMap) }
+            defaultMap
         }
-        _activeProfile.value = savedProfile
+        profileMap.clear()
+        profileMap.putAll(map)
+
+        val savedProfile = prefs[ACTIVE_KEY] ?: DEFAULT
+        _activeProfile.value = if (map.containsKey(savedProfile)) savedProfile else DEFAULT
     }
 
     fun getProfilesFlow(context: Context): Flow<Set<String>> =
-        context.applicationContext.globalDataStore.data.map {
-            it[NAMES_KEY] ?: setOf(DEFAULT)
+        context.applicationContext.globalDataStore.data.map { prefs ->
+            prefs[PROFILES_KEY]?.let { parseProfileMap(it).keys.toSet() } ?: setOf(DEFAULT)
         }
 
     suspend fun switchProfile(context: Context, name: String) {
@@ -70,19 +95,24 @@ object ProfileManager {
     }
 
     suspend fun createProfile(context: Context, name: String) {
+        val id = UUID.randomUUID().toString()
+        profileMap[name] = id
         context.applicationContext.globalDataStore.edit { prefs ->
-            prefs[NAMES_KEY] = (prefs[NAMES_KEY] ?: setOf(DEFAULT)) + name
+            val current = prefs[PROFILES_KEY]?.let { parseProfileMap(it) } ?: mapOf(DEFAULT to DEFAULT_ID)
+            prefs[PROFILES_KEY] = serializeProfileMap(current + (name to id))
         }
     }
 
     suspend fun deleteProfile(context: Context, name: String) {
         if (name == DEFAULT || name == _activeProfile.value) return
+        val id = profileMap.remove(name) ?: return
         context.applicationContext.globalDataStore.edit { prefs ->
-            prefs[NAMES_KEY] = (prefs[NAMES_KEY] ?: setOf(DEFAULT)) - name
+            val current = prefs[PROFILES_KEY]?.let { parseProfileMap(it) } ?: mapOf(DEFAULT to DEFAULT_ID)
+            prefs[PROFILES_KEY] = serializeProfileMap(current - name)
         }
-        synchronized(this) { storeCache.remove(name) }
+        storeCache.remove(id)
         val appContext = context.applicationContext
-        val fileName = "settings_${sanitize(name)}"
+        val fileName = "settings_$id"
         appContext.filesDir.resolve("datastore/$fileName.preferences_pb").delete()
         appContext.filesDir.resolve("datastore/$fileName.preferences_pb.tmp").delete()
     }

--- a/app/src/main/java/dev/fabik/bluetoothhid/utils/ProfileManager.kt
+++ b/app/src/main/java/dev/fabik/bluetoothhid/utils/ProfileManager.kt
@@ -1,0 +1,89 @@
+package dev.fabik.bluetoothhid.utils
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.datastore.preferences.core.stringSetPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
+
+// Separate store for profile metadata — never part of any profile's settings
+private val Context.globalDataStore: DataStore<Preferences> by preferencesDataStore("global")
+
+object ProfileManager {
+    const val DEFAULT = "Default"
+    private val ACTIVE_KEY = stringPreferencesKey("active_profile")
+    private val NAMES_KEY = stringSetPreferencesKey("profile_names")
+
+    private val storeCache = HashMap<String, DataStore<Preferences>>()
+
+    private val _activeProfile = MutableStateFlow(DEFAULT)
+    val activeProfile: StateFlow<String> = _activeProfile.asStateFlow()
+
+    private fun sanitize(name: String) = name.lowercase().replace(Regex("[^a-z0-9_]"), "_")
+
+    @Synchronized
+    fun getOrCreateStore(context: Context, profileName: String): DataStore<Preferences> {
+        return storeCache.getOrPut(profileName) {
+            val appContext = context.applicationContext
+            // Default profile reuses the existing settings.preferences_pb file (backward compat)
+            val fileName = if (profileName == DEFAULT) "settings" else "settings_${sanitize(profileName)}"
+            PreferenceDataStoreFactory.create {
+                appContext.filesDir.resolve("datastore/$fileName.preferences_pb")
+            }
+        }
+    }
+
+    fun currentStore(context: Context): DataStore<Preferences> =
+        getOrCreateStore(context, _activeProfile.value)
+
+    fun activeStoreFlow(context: Context): Flow<DataStore<Preferences>> =
+        _activeProfile.map { getOrCreateStore(context, it) }
+
+    suspend fun initialize(context: Context) {
+        val appContext = context.applicationContext
+        val prefs = appContext.globalDataStore.data.first()
+        val savedProfile = prefs[ACTIVE_KEY] ?: DEFAULT
+        // Ensure the profiles list always contains at least Default
+        if (prefs[NAMES_KEY] == null) {
+            appContext.globalDataStore.edit { it[NAMES_KEY] = setOf(DEFAULT) }
+        }
+        _activeProfile.value = savedProfile
+    }
+
+    fun getProfilesFlow(context: Context): Flow<Set<String>> =
+        context.applicationContext.globalDataStore.data.map {
+            it[NAMES_KEY] ?: setOf(DEFAULT)
+        }
+
+    suspend fun switchProfile(context: Context, name: String) {
+        _activeProfile.value = name
+        context.applicationContext.globalDataStore.edit { it[ACTIVE_KEY] = name }
+    }
+
+    suspend fun createProfile(context: Context, name: String) {
+        context.applicationContext.globalDataStore.edit { prefs ->
+            prefs[NAMES_KEY] = (prefs[NAMES_KEY] ?: setOf(DEFAULT)) + name
+        }
+    }
+
+    suspend fun deleteProfile(context: Context, name: String) {
+        if (name == DEFAULT || name == _activeProfile.value) return
+        context.applicationContext.globalDataStore.edit { prefs ->
+            prefs[NAMES_KEY] = (prefs[NAMES_KEY] ?: setOf(DEFAULT)) - name
+        }
+        synchronized(this) { storeCache.remove(name) }
+        val appContext = context.applicationContext
+        val fileName = "settings_${sanitize(name)}"
+        appContext.filesDir.resolve("datastore/$fileName.preferences_pb").delete()
+        appContext.filesDir.resolve("datastore/$fileName.preferences_pb.tmp").delete()
+    }
+}

--- a/app/src/main/java/dev/fabik/bluetoothhid/utils/ProfileManager.kt
+++ b/app/src/main/java/dev/fabik/bluetoothhid/utils/ProfileManager.kt
@@ -7,6 +7,7 @@ import androidx.datastore.preferences.core.PreferenceDataStoreFactory
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
+import androidx.datastore.preferences.preferencesDataStoreFile
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -49,10 +50,10 @@ object ProfileManager {
     private fun getOrCreateStoreById(context: Context, fileId: String): DataStore<Preferences> {
         return storeCache.getOrPut(fileId) {
             val appContext = context.applicationContext
-            // Default profile reuses the existing settings.preferences_pb (backward compat)
+            // Default profile reuses the existing "settings" store (backward compat)
             val fileName = if (fileId == DEFAULT_ID) "settings" else "settings_$fileId"
             PreferenceDataStoreFactory.create {
-                appContext.filesDir.resolve("datastore/$fileName.preferences_pb")
+                appContext.preferencesDataStoreFile(fileName)
             }
         }
     }

--- a/app/src/main/java/dev/fabik/bluetoothhid/utils/ScanAreaData.kt
+++ b/app/src/main/java/dev/fabik/bluetoothhid/utils/ScanAreaData.kt
@@ -1,0 +1,65 @@
+package dev.fabik.bluetoothhid.utils
+
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.geometry.Size
+import org.json.JSONArray
+import org.json.JSONObject
+import kotlin.math.absoluteValue
+
+data class ScanAreaData(
+    val posX: Float = 0f,
+    val posY: Float = 0f,
+    val sizeX: Float = 100f,
+    val sizeY: Float = 100f
+) {
+    // Converts to screen Rect using the same formula as OverlayCanvas CUSTOM type
+    fun toRect(screenWidth: Float, screenHeight: Float): Rect {
+        val cx = screenWidth / 2
+        val cy = screenHeight / 2
+        return Rect(
+            Offset(cx + posX - sizeX.absoluteValue, cy + posY - sizeY.absoluteValue),
+            Offset(cx + posX + sizeX.absoluteValue, cy + posY + sizeY.absoluteValue)
+        )
+    }
+
+    fun withPosition(posX: Float, posY: Float) = copy(posX = posX, posY = posY)
+    fun withSize(sizeX: Float, sizeY: Float) = copy(sizeX = sizeX, sizeY = sizeY)
+
+    private fun toJson() = JSONObject().apply {
+        put("posX", posX.toDouble())
+        put("posY", posY.toDouble())
+        put("sizeX", sizeX.toDouble())
+        put("sizeY", sizeY.toDouble())
+    }
+
+    companion object {
+        val DEFAULT = ScanAreaData()
+
+        fun fromPrefs(posX: Float, posY: Float, sizeX: Float, sizeY: Float) =
+            ScanAreaData(posX, posY, sizeX, sizeY)
+
+        fun fromJsonArray(json: String): List<ScanAreaData> {
+            if (json.isBlank()) return emptyList()
+            return runCatching {
+                val arr = JSONArray(json)
+                (0 until arr.length()).map { i ->
+                    val obj = arr.getJSONObject(i)
+                    ScanAreaData(
+                        obj.getDouble("posX").toFloat(),
+                        obj.getDouble("posY").toFloat(),
+                        obj.getDouble("sizeX").toFloat(),
+                        obj.getDouble("sizeY").toFloat()
+                    )
+                }
+            }.getOrDefault(emptyList())
+        }
+
+        fun toJsonArray(areas: List<ScanAreaData>): String =
+            JSONArray(areas.map { it.toJson() }).toString()
+
+        // Computes the Compose Size for an area (for drag handle placement)
+        fun ScanAreaData.toOverlaySize() = Size(sizeX, sizeY)
+        fun ScanAreaData.toOverlayOffset() = Offset(posX, posY)
+    }
+}

--- a/app/src/main/res/values-pl-rPL/strings.xml
+++ b/app/src/main/res/values-pl-rPL/strings.xml
@@ -321,6 +321,10 @@
     <string name="add">Dodaj</string>
     <string name="persistent_history">Trwała historia skanowania</string>
     <string name="persistent_history_desc">Pamiętaj skanowane kody pomiędzy sesjami</string>
+    <string name="multi_code_detection">Wykrywanie wielu kodów</string>
+    <string name="multi_code_detection_desc">Wykrywa i kolejkuje wszystkie kody kreskowe widoczne w kadrze jednocześnie</string>
+    <string name="add_scan_area">Dodaj obszar</string>
+    <string name="delete_scan_area">Usuń obszar</string>
     <string name="filter">Filtr</string>
     <string name="date_range">Zakres dat</string>
     <string name="select_types">Wybierz typy</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -254,6 +254,10 @@
     <string name="add">Add</string>
     <string name="persistent_history">Persistent history</string>
     <string name="persistent_history_desc">Remembers the scan history</string>
+    <string name="multi_code_detection">Multi-code detection</string>
+    <string name="multi_code_detection_desc">Detect and queue all barcodes visible in the frame at once</string>
+    <string name="add_scan_area">Add area</string>
+    <string name="delete_scan_area">Delete area</string>
     <string name="filter">Filter</string>
     <string name="date_range">Date range</string>
     <string name="select_types">Select Types</string>
@@ -424,4 +428,12 @@
         <item>Toggle zoom</item>
         <item>Trigger focus</item>
     </string-array>
+    <string name="profiles">Profiles</string>
+    <string name="active_profile_desc">Tap to manage profiles</string>
+    <string name="manage_profiles">Manage profiles</string>
+    <string name="add_profile">Add profile</string>
+    <string name="delete_profile">Delete profile</string>
+    <string name="profile_name">Profile name</string>
+    <string name="profile_name_empty">Profile name cannot be empty</string>
+    <string name="profile_name_exists">A profile with this name already exists</string>
 </resources>


### PR DESCRIPTION
  Closes #485 · Closes #380 · Closes #285 · Closes #540

  This PR is an initial implementation of several long-requested features. Each works end-to-end but may still need polish before merge.

  - Preference profiles (#485): users can create, switch, and delete named profiles, each with its own independent DataStore; the active profile is persisted across sessions
  and all preference reads/writes are routed through ProfileManager
  - Multiple custom scan areas (#380): the CUSTOM overlay now supports adding, moving, and resizing any number of independent scan areas; positions are stored as JSON in a new
   SCAN_AREAS preference with automatic migration from the old single-area floats
  - Dynamic code selection (#285): new MULTI_CODE_DETECTION toggle — when AUTO_SEND is on every detected code is queued and sent; when off, a chip bar lets the user tap to
  choose which code to send
  - Settings stability: fixed LocalDataStore not provided crash in SettingsActivity and settings controls not rendering

@Fabi019 — happy to collaborate on finishing this if you're interested. I'd especially appreciate your thoughts on the profiles UX and whether the ProfileManager approach fits your architecture vision. Let me know what needs reworking before this could be merged!

  Known rough edges / suggestions welcome:
  - Profile switching UX (rename, reorder, copy from another profile?)
  - Scan area persistence when switching profiles
  - Multi-code picker positioning and dismiss behavior
  - Edge cases around AUTO_SEND + MULTI_CODE_DETECTION interaction (e.g. dedup across sessions)
  - Migration path for users upgrading from single scan area